### PR TITLE
use compute=False in to_netcdf

### DIFF
--- a/clisops/utils/output_utils.py
+++ b/clisops/utils/output_utils.py
@@ -135,10 +135,14 @@ def get_output(result_ds, output_type, output_dir, namer):
 
     file_name = namer.get_file_name(result_ds, fmt=output_type)
 
-    writer = getattr(result_ds, fmt_method)
+    # writer = getattr(result_ds, fmt_method)
     output_path = os.path.join(output_dir, file_name)
 
     # TODO: compute=True is blocking wps process. How to handle?
-    writer(output_path, compute=False)
+    # writer(output_path, compute=False)
+    if fmt_method == 'to_netcdf':
+        result_ds.to_netcdf(output_path, compute=False)
+    else:
+        raise NotImplementedError('output format not supported')
     LOGGER.info(f"Wrote output file: {output_path}")
     return output_path

--- a/clisops/utils/output_utils.py
+++ b/clisops/utils/output_utils.py
@@ -127,6 +127,7 @@ def get_time_slices(ds, split_method, start=None, end=None, file_size_limit=None
 def get_output(result_ds, output_type, output_dir, namer):
 
     fmt_method = get_format_writer(output_type)
+    LOGGER.info(f"fmt_method={fmt_method}, output_type={output_type}")
 
     if not fmt_method:
         LOGGER.info(f"Returning output as {type(result_ds)}")
@@ -137,6 +138,7 @@ def get_output(result_ds, output_type, output_dir, namer):
     writer = getattr(result_ds, fmt_method)
     output_path = os.path.join(output_dir, file_name)
 
-    writer(output_path)
+    # TODO: compute=True is blocking wps process. How to handle?
+    writer(output_path, compute=False)
     LOGGER.info(f"Wrote output file: {output_path}")
     return output_path


### PR DESCRIPTION
The WPS processes are in some cases blocked by `ds.to_netcdf(compute=True)` (default). With `compute=False` the blocking does not occur.  But maybe files are not written before WPS response is send?