### PR TITLE
added workaround for to_netcdf

### DIFF
--- a/clisops/__init__.py
+++ b/clisops/__init__.py
@@ -17,8 +17,12 @@ logging.config.fileConfig(
 )
 CONFIG = get_config(clisops)
 
+
 # Set the memory limit for each dask chunk
 chunk_memory_limit = CONFIG["clisops:read"].get("chunk_memory_limit", None)
 
-if chunk_memory_limit:
-    dask.config.set({"array.chunk-size": chunk_memory_limit})
+# if get_chunk_mem_limit():
+#     dask.config.set({"array.chunk-size": get_chunk_mem_limit()})
+
+for key, value in CONFIG["environment"].items():
+    os.environ[key.upper()] = value

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -1,12 +1,14 @@
 import os
+import tempfile
 
 import xarray as xr
 from roocs_utils.parameter import parameterise
+from roocs_utils.xarray_utils import xarray_utils as xu
 
 from clisops import logging, utils
 from clisops.core import subset_bbox, subset_time
 from clisops.utils.file_namers import get_file_namer
-from clisops.utils.output_utils import get_output, get_time_slices
+from clisops.utils.output_utils import _get_chunked_dataset, get_output, get_time_slices
 
 __all__ = [
     "subset",
@@ -16,7 +18,6 @@ LOGGER = logging.getLogger(__file__)
 
 
 def _subset(ds, args):
-
     if "lon_bnds" and "lat_bnds" in args:
         # subset with space and optionally time
         LOGGER.debug(f"subset_bbox with parameters: {args}")
@@ -73,7 +74,6 @@ def subset(
     outputs = []
 
     namer = get_file_namer(file_namer)()
-
     for tslice in time_slices:
         # update args with tslice start and end
         args["start_date"], args["end_date"] = tslice[0], tslice[1]

--- a/clisops/utils/output_utils.py
+++ b/clisops/utils/output_utils.py
@@ -1,11 +1,13 @@
+import math
 import os
+import sys
 
 import pandas as pd
 import xarray as xr
 from roocs_utils.utils.common import parse_size
 from roocs_utils.xarray_utils import xarray_utils as xu
 
-from clisops import CONFIG, logging
+from clisops import CONFIG, chunk_memory_limit, logging
 
 LOGGER = logging.getLogger(__file__)
 
@@ -48,7 +50,6 @@ def filter_times_within(times, start=None, end=None):
     are defined and are within the main array.
     """
     filtered = []
-
     for tm in times:
         ft = _format_time(tm, "%Y-%m-%dT%H:%M:%S")
         if start is not None and ft < start:
@@ -59,6 +60,16 @@ def filter_times_within(times, start=None, end=None):
         filtered.append(tm)
 
     return filtered
+
+
+def get_da(ds):
+    if isinstance(ds, xr.DataArray):
+        da = ds
+    else:
+        var_id = xu.get_main_variable(ds)
+        da = ds[var_id]
+
+    return da
 
 
 def get_time_slices(ds, split_method, start=None, end=None, file_size_limit=None):
@@ -87,11 +98,7 @@ def get_time_slices(ds, split_method, start=None, end=None, file_size_limit=None
     if not file_size_limit:
         file_size_limit = parse_size(CONFIG["clisops:write"]["file_size_limit"])
 
-    if isinstance(ds, xr.DataArray):
-        da = ds
-    else:
-        var_id = xu.get_main_variable(ds)
-        da = ds[var_id]
+    da = get_da(ds)
 
     times = filter_times_within(da.time.values, start=start, end=end)
     n_times = len(times)
@@ -124,18 +131,45 @@ def get_time_slices(ds, split_method, start=None, end=None, file_size_limit=None
     return slices
 
 
-def get_output(result_ds, output_type, output_dir, namer):
+def get_chunk_length(ds):
+    da = get_da(ds)
+    size = da.nbytes
+    n_times = len(da.time.values)
+    mem_limit = parse_size(chunk_memory_limit)
+
+    if size > 0:
+        n_chunks = math.ceil(size / mem_limit)
+    else:
+        n_chunks = 1
+
+    chunk_length = math.ceil(n_times / n_chunks)
+
+    return chunk_length
+
+
+def _get_chunked_dataset(ds):
+    da = get_da(ds)
+    chunk_length = get_chunk_length(ds)
+    chunked_ds = ds.chunk({"time": chunk_length})
+    da.unify_chunks()
+    return chunked_ds
+
+
+def get_output(ds, output_type, output_dir, namer):
 
     fmt_method = get_format_writer(output_type)
     LOGGER.info(f"fmt_method={fmt_method}, output_type={output_type}")
 
     if not fmt_method:
-        LOGGER.info(f"Returning output as {type(result_ds)}")
-        return result_ds
+        LOGGER.info(f"Returning output as {type(ds)}")
+        return ds
 
-    file_name = namer.get_file_name(result_ds, fmt=output_type)
+    file_name = namer.get_file_name(ds, fmt=output_type)
+
+    chunked_ds = _get_chunked_dataset(ds)
 
     # writer = getattr(result_ds, fmt_method)
+
     output_path = os.path.join(output_dir, file_name)
 
     # TODO: writing output works currently only in sync mode.
@@ -146,7 +180,8 @@ def get_output(result_ds, output_type, output_dir, namer):
         import dask
 
         with dask.config.set(scheduler="synchronous"):
-            result_ds.to_netcdf(output_path, compute=True)
+            chunked_ds.to_netcdf(output_path, compute=False)
+            chunked_ds.compute()
     else:
         raise NotImplementedError("output format not supported")
     LOGGER.info(f"Wrote output file: {output_path}")

--- a/clisops/utils/output_utils.py
+++ b/clisops/utils/output_utils.py
@@ -141,12 +141,13 @@ def get_output(result_ds, output_type, output_dir, namer):
     # TODO: writing output works currently only in sync mode.
     # https://github.com/roocs/rook/issues/55
     # writer(output_path, compute=True)
-    if fmt_method == 'to_netcdf':
+    if fmt_method == "to_netcdf":
         # TODO: https://docs.dask.org/en/latest/scheduling.html
         import dask
-        with dask.config.set(scheduler='synchronous'):
+
+        with dask.config.set(scheduler="synchronous"):
             result_ds.to_netcdf(output_path, compute=True)
     else:
-        raise NotImplementedError('output format not supported')
+        raise NotImplementedError("output format not supported")
     LOGGER.info(f"Wrote output file: {output_path}")
     return output_path

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -1,14 +1,20 @@
 import os
 import sys
+from unittest.mock import Mock
 
 import pytest
+import xarray as xr
+from memory_profiler import memory_usage
 from roocs_utils.exceptions import InvalidParameterValue, MissingParameterValue
 from roocs_utils.parameter import area_parameter, time_parameter
 from roocs_utils.utils.common import parse_size
 
+import clisops
 from clisops import CONFIG
-from clisops.ops.subset import subset
-from clisops.utils.output_utils import _format_time, get_time_slices
+from clisops.ops.subset import _subset, subset
+from clisops.utils import map_params, output_utils
+from clisops.utils.file_namers import get_file_namer
+from clisops.utils.output_utils import _format_time, get_output, get_time_slices
 
 from .._common import CMIP5_RH, CMIP5_TAS, CMIP5_TAS_FILE, CMIP5_ZOSTOGA
 

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock
 
 import pytest
 import xarray as xr
-from memory_profiler import memory_usage
 from roocs_utils.exceptions import InvalidParameterValue, MissingParameterValue
 from roocs_utils.parameter import area_parameter, time_parameter
 from roocs_utils.utils.common import parse_size

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from dateutil.parser import ParserError
 from roocs_utils.exceptions import InvalidParameterValue, MissingParameterValue
@@ -10,6 +12,12 @@ from ._common import CMIP5_TAS_FILE
 def test_local_config_loads():
     assert "clisops:read" in CONFIG
     assert "file_size_limit" in CONFIG["clisops:write"]
+
+
+def test_dask_env_variables():
+    assert os.getenv("MKL_NUM_THREADS") == "1"
+    assert os.getenv("OPENBLAS_NUM_THREADS") == "1"
+    assert os.getenv("OMP_NUM_THREADS") == "1"
 
 
 @pytest.mark.xfail(reason="parse_date removed as date parsed in TimeParameter class")


### PR DESCRIPTION
This PR adds a workaround for the hanging `to_netcdf` output.

Related issue in rook:
https://github.com/roocs/rook/issues/55