### PR TITLE
Core subset time in gap fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,25 +2,25 @@ Copyright 2018 United Kingdom Research and Innovation
 
 Authors: Elle Smith
 
-Redistribution and use in source and binary forms, with or without 
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, 
-   this list of conditions and the following disclaimer in the documentation 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors 
-   may be used to endorse or promote products derived from this software 
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
    without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -11,11 +11,10 @@ import pandas as pd
 import xarray
 from pyproj import Geod
 from pyproj.crs import CRS
+from roocs_utils.utils.time_utils import to_isoformat
 from shapely import vectorized
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.ops import cascaded_union, split
-
-from roocs_utils.utils.time_utils import to_isoformat
 
 __all__ = [
     "create_mask",

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -89,7 +89,7 @@ def check_start_end_dates(func):
                 UserWarning,
                 stacklevel=2,
             )
-            nudged = da.time.sel(time=slice(None, kwargs["end_date"])).values[-1] 
+            nudged = da.time.sel(time=slice(None, kwargs["end_date"])).values[-1]
             kwargs["end_date"] = to_isoformat(nudged)
 
         if (

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -49,7 +49,9 @@ def check_start_end_dates(func):
             kwargs["end_date"] = str(kwargs["end_date"])
 
         try:
-            da.time.sel(time=kwargs["start_date"])
+            sel_times = da.time.sel(time=kwargs["start_date"])
+            if len(sel_times) == 0:
+                raise ValueError()
         except KeyError:
             warnings.warn(
                 '"start_date" not found within input date time range. Defaulting to minimum time step in '
@@ -58,8 +60,18 @@ def check_start_end_dates(func):
                 stacklevel=2,
             )
             kwargs["start_date"] = da.time.min().dt.strftime("%Y").values
+        except ValueError:
+            warnings.warn(
+                '"start_date" has been nudged to nearest valid time step in xarray object.'
+                UserWarning,
+                stacklevel=2,
+            )
+            kwargs["start_date"] = da.time.min().dt.strftime("%Y").values
+
         try:
-            da.time.sel(time=kwargs["end_date"])
+            sel_times = da.time.sel(time=kwargs["end_date"])
+            if len(sel_times) == 0:
+                raise ValueError()
         except KeyError:
             warnings.warn(
                 '"end_date" not found within input date time range. Defaulting to maximum time step in '
@@ -68,6 +80,14 @@ def check_start_end_dates(func):
                 stacklevel=2,
             )
             kwargs["end_date"] = da.time.max().dt.strftime("%Y").values
+        except ValueError:
+            warnings.warn(
+                '"end_date" has been nudged to nearest valid time step in xarray object.'
+                UserWarning,
+                stacklevel=2,
+            )
+            kwargs["end_date"] = da.time.min().dt.strftime("%Y").values
+
         if (
             da.time.sel(time=kwargs["start_date"]).min()
             > da.time.sel(time=kwargs["end_date"]).max()

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -25,6 +25,13 @@ __all__ = [
     "subset_time",
 ]
 
+#TODO: put this in roocs-utils, and refactor dachar to use it
+def _format_time(tm):
+    if type(tm) == np.datetime64:
+        return str(tm).split(".")[0]
+    else:
+        return tm.isoformat()
+
 
 def check_start_end_dates(func):
     @wraps(func)

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -68,21 +68,19 @@ def subset(
     LOGGER.debug(f"Mapping parameters: time: {time}, area: {area}, level: {level}")
     args = utils.map_params(ds, time, area, level)
 
-    time_slices = get_time_slices(
-        ds, split_method, start=args["start_date"], end=args["end_date"]
-    )
+    subset_ds = _subset(ds, args)
+
     outputs = []
-
     namer = get_file_namer(file_namer)()
-    for tslice in time_slices:
-        # update args with tslice start and end
-        args["start_date"], args["end_date"] = tslice[0], tslice[1]
 
+    time_slices = get_time_slices(subset_ds, split_method) 
+
+    for tslice in time_slices:
+
+        result_ds = subset_ds.sel(time=slice(tslice[0], tslice[1]))
         LOGGER.info(f"Processing subset for times: {tslice}")
-        result_ds = _subset(ds, args)
 
         output = get_output(result_ds, output_type, output_dir, namer)
-
         outputs.append(output)
 
     return outputs

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -73,7 +73,7 @@ def subset(
     outputs = []
     namer = get_file_namer(file_namer)()
 
-    time_slices = get_time_slices(subset_ds, split_method) 
+    time_slices = get_time_slices(subset_ds, split_method)
 
     for tslice in time_slices:
 

--- a/clisops/utils/output_utils.py
+++ b/clisops/utils/output_utils.py
@@ -169,7 +169,8 @@ def get_output(ds, output_type, output_dir, namer):
     file_name = namer.get_file_name(ds, fmt=output_type)
     chunked_ds = _get_chunked_dataset(ds)
 
-    if not output_dir: output_dir = '.'
+    if not output_dir:
+        output_dir = '.'
     output_path = os.path.join(output_dir, file_name)
 
     # TODO: writing output works currently only in sync mode, see:

--- a/clisops/utils/output_utils.py
+++ b/clisops/utils/output_utils.py
@@ -2,10 +2,9 @@ import math
 import os
 import sys
 
+import dask
 import pandas as pd
 import xarray as xr
-import dask
-
 from roocs_utils.utils.common import parse_size
 from roocs_utils.xarray_utils import xarray_utils as xu
 
@@ -170,7 +169,7 @@ def get_output(ds, output_type, output_dir, namer):
     chunked_ds = _get_chunked_dataset(ds)
 
     if not output_dir:
-        output_dir = '.'
+        output_dir = "."
     output_path = os.path.join(output_dir, file_name)
 
     # TODO: writing output works currently only in sync mode, see:

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -74,14 +74,12 @@ class TestSubsetTime:
 
         with pytest.warns(None) as record:
             subset.subset_time(
-                da,
-                start_date='2064-01-01T00:00:00',
-                end_date='2065-02-01T03:12:01'
+                da, start_date="2064-01-01T00:00:00", end_date="2065-02-01T03:12:01"
             )
-        assert ([str(q.message) for q in record] ==
-                ['"start_date" has been nudged to nearest valid time step in xarray object.',
-                    '"end_date" has been nudged to nearest valid time step in xarray object.']
-                )
+        assert [str(q.message) for q in record] == [
+            '"start_date" has been nudged to nearest valid time step in xarray object.',
+            '"end_date" has been nudged to nearest valid time step in xarray object.',
+        ]
 
     def test_time_start_only(self):
         da = xr.open_dataset(self.nc_poslons).tas

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -72,6 +72,18 @@ class TestSubsetTime:
             in [str(q.message) for q in record]
         )
 
+        with pytest.warns(None) as record:
+            subset.subset_time(
+                da,
+                start_date='2064-01-01T00:00:00',
+                end_date='2065-02-01T03:12:01'
+            )
+        assert ([str(q.message) for q in record] == \
+            ['"start_date" has been nudged to nearest valid time step in xarray object.',
+            '"end_date" has been nudged to nearest valid time step in xarray object.']
+        )
+
+
     def test_time_start_only(self):
         da = xr.open_dataset(self.nc_poslons).tas
         yr_st = "2050"

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -78,11 +78,10 @@ class TestSubsetTime:
                 start_date='2064-01-01T00:00:00',
                 end_date='2065-02-01T03:12:01'
             )
-        assert ([str(q.message) for q in record] == \
-            ['"start_date" has been nudged to nearest valid time step in xarray object.',
-            '"end_date" has been nudged to nearest valid time step in xarray object.']
-        )
-
+        assert ([str(q.message) for q in record] ==
+                ['"start_date" has been nudged to nearest valid time step in xarray object.',
+                    '"end_date" has been nudged to nearest valid time step in xarray object.']
+                )
 
     def test_time_start_only(self):
         da = xr.open_dataset(self.nc_poslons).tas

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -101,7 +101,7 @@ def test_subset_area_simple_file_name(tmpdir):
     """ Tests clisops subset function with a area subset (simple file name)."""
     result = subset(
         ds=CMIP5_TAS_FILE,
-        area=(0.0, 49.0, 10.0, 65.0),
+        area=(0.0, 10.0, 10.0, 65.0),
         output_dir=tmpdir,
         output_type="nc",
         file_namer="simple",
@@ -113,7 +113,7 @@ def test_subset_area_project_file_name(tmpdir):
     """ Tests clisops subset function with a area subset (derived file name)."""
     result = subset(
         ds=CMIP5_TAS_FILE,
-        area=(0.0, 49.0, 10.0, 65.0),
+        area=(0.0, 10.0, 10.0, 65.0),
         output_dir=tmpdir,
         output_type="nc",
         file_namer="standard",
@@ -149,7 +149,7 @@ def test_subset_with_time_and_area(tmpdir):
     result = subset(
         ds=CMIP5_TAS_FILE,
         time=("2019-01-01T00:00:00", "2020-12-30T00:00:00"),
-        area=(0.0, 49.0, 10.0, 65.0),
+        area=(0.0, 0.0, 10.0, 65.0),
         output_dir=tmpdir,
         output_type="nc",
         file_namer="simple",
@@ -162,7 +162,7 @@ def test_subset_with_multiple_files_tas(tmpdir):
     result = subset(
         ds=CMIP5_TAS,
         time=("2001-01-01T00:00:00", "2020-12-30T00:00:00"),
-        area=(0.0, 49.0, 10.0, 65.0),
+        area=(0.0, 0.0, 10.0, 65.0),
         output_dir=tmpdir,
         output_type="nc",
         file_namer="simple",
@@ -222,10 +222,11 @@ def test_time_slices_in_subset_tas():
     config_max_file_size = CONFIG["clisops:write"]["file_size_limit"]
     temp_max_file_size = "10KB"
     CONFIG["clisops:write"]["file_size_limit"] = temp_max_file_size
+
     outputs = subset(
         ds=CMIP5_TAS,
         time=(start_time, end_time),
-        area=(0.0, 49.0, 10.0, 65.0),
+        area=(0.0, 5.0, 50.0, 90.0),
         output_type="xarray",
         file_namer="simple",
     )
@@ -256,7 +257,7 @@ def test_time_slices_in_subset_rh():
     outputs = subset(
         ds=CMIP5_RH,
         time=(start_time, end_time),
-        area=(0.0, 49.0, 10.0, 65.0),
+        area=(0.0, 5.0, 50.0, 90.0),
         output_type="xarray",
         file_namer="simple",
     )


### PR DESCRIPTION
@huard and @Zeitsperre , I invite you to review this PR on clisops. There are two main components:

1. Changes in `clisops.core.subset#check_start_end_dates` decorator:
  - see: https://github.com/roocs/clisops/commit/96aceeccf2937b2261546503c571c89423e65c8e
  - there was an issue that picking times _between_ valid time values would cause an error, I have changed this so that the `start_date` and `end_date` will be _nudged_ to the adjacent valid value.

2. I have restructured our `clisops.ops.subset#subset` function so that it now correctly calls `clisops.core.subset` functions before working out how to chunk/split datasets:
 - see: https://github.com/roocs/clisops/commit/19ddf49179080935f065a63e78d717580de63154

