### PR TITLE
fixed subset result and removed old tests

### DIFF
--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__file__)
 
 
 def _subset(ds, args):
+
     if "lon_bnds" and "lat_bnds" in args:
         # subset with space and optionally time and level
         LOGGER.debug(f"subset_bbox with parameters: {args}")
@@ -32,6 +33,9 @@ def _subset(ds, args):
         if any(kwargs.values()):
             LOGGER.debug(f"subset_time with parameters: {kwargs}")
             result = subset_time(ds, **kwargs)
+
+        else:
+            result = ds
 
         kwargs = {}
         valid_args = ["first_level", "last_level"]

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -27,14 +27,15 @@ def _load_ds(fpath):
     return xr.open_mfdataset(fpath)
 
 
-@pytest.mark.xfail(
-    reason="Time, Level and area can all be none as they default to max/min values"
-    "in core.subset"
-)
-def test_subset_missing_param(tmpdir):
+def test_subset_no_params(tmpdir):
     """ Test subset without area param."""
-    with pytest.raises(MissingParameterValue):
-        subset(ds=CMIP5_TAS_FILE, output_dir=tmpdir)
+    result = subset(
+        ds=CMIP5_TAS_FILE,
+        output_dir=tmpdir,
+        output_type="nc",
+        file_namer="simple",
+    )
+    _check_output_nc(result)
 
 
 def test_subset_time(tmpdir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,23 +20,6 @@ def test_dask_env_variables():
     assert os.getenv("OMP_NUM_THREADS") == "1"
 
 
-@pytest.mark.xfail(reason="parse_date removed as date parsed in TimeParameter class")
-def test_parse_date():
-    assert "2020-05-19" == utils.parse_date("2020-05-19")
-    assert "1999-01-01" == utils.parse_date("1999-01-01T00:00:00")
-    with pytest.raises(ParserError):
-        utils.parse_date("tomorrow")
-
-
-@pytest.mark.xfail(
-    reason="parse_date_year removed as date parsed in TimeParameter class"
-)
-def test_parse_date_year():
-    assert "2020" == utils.parse_date_year("2020-05-20")
-    with pytest.raises(ParserError):
-        utils.parse_date_year("yesterday")
-
-
 def test_map_params():
     args = utils.map_params(
         ds=CMIP5_TAS_FILE,
@@ -98,12 +81,3 @@ def test_map_params_invalid_area():
             ds=CMIP5_TAS_FILE,
             area=("zero", 10, 50, 60),
         )
-
-
-@pytest.mark.xfail(
-    reason="Time, Level and area can all be none as they default to max/min values"
-    "in core.subset"
-)
-def test_map_params_missing_param():
-    with pytest.raises(MissingParameterValue):
-        utils.map_params()


### PR DESCRIPTION
Result = None method raised error `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()` with another test so I changed the method slightly.

Also removed so old tests marked as xfail