### PR TITLE
Allow for subset with simple geometries

### DIFF
--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -539,6 +539,12 @@ def subset_shape(
     Union[xarray.DataArray, xarray.Dataset]
       A subset of `ds`
 
+    Notes
+    -----
+    If no CRS is found in the shape provided (e.g. RFC-7946 GeoJSON, https://en.wikipedia.org/wiki/GeoJSON),
+    assumes a decimal degree datum (CRS84). Be advised that EPSG:4326 and OGC:CRS84 are not identical as axis order of
+    lat and long differs between the two (for more information, see: https://github.com/OSGeo/gdal/issues/2035).
+
     Examples
     --------
     >>> import xarray as xr  # doctest: +SKIP


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #95
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion minor` has been called on this branch
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
This adds a catch for sending a shape object that has no defined CRS (like a geometry made with a few Shapely points). Otherwise, the subset will fail at runtime.

This also changes the priority in which a `wrap_lons` flag is established. If lons never exceed 180 in WGS84, there is no need to wrap them.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No.

* **Other information:**: <!--(Relevant discussion threads? Outside documentation pages?)-->
