### PR TITLE
Include boundary points in subset_polygon

### DIFF
--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -474,14 +474,18 @@ def create_mask(
         dims_out = x_dim.dims
         coords_out = x_dim.coords
 
-    # try vectorize
+    # vectorize
     mask = np.zeros(lat1.shape) + np.nan
     for pp in reversed(poly.index):
         for vv in poly[poly.index == pp].geometry.values:
-            b1 = vectorized.contains(vv, lon1.flatten(), lat1.flatten()).reshape(
+            contained = vectorized.contains(vv, lon1.flatten(), lat1.flatten()).reshape(
                 lat1.shape
             )
-            mask[b1] = pp
+            touched = vectorized.touches(vv, lon1.flatten(), lat1.flatten()).reshape(
+                lat1.shape
+            )
+            intersection = np.logical_or(contained, touched)
+            mask[intersection] = pp
 
     mask = xarray.DataArray(mask, dims=dims_out, coords=coords_out)
 

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -4,6 +4,7 @@ import geopandas as gpd
 import numpy as np
 import pytest
 import xarray as xr
+from shapely.geometry import Polygon
 
 from clisops.core import subset
 
@@ -783,6 +784,20 @@ class TestSubsetShape:
         regions.set_index("id")
         ds_sub = subset.subset_shape(ds, shape=regions)
         assert ds_sub.notnull().sum() == 58 + 250 + 22
+
+    def test_vectorize_touches_polygons(self):
+        """Check that points touching the polygon are included in subset."""
+        # Create simple polygon
+        poly = Polygon([[0, 0], [1, 0], [1, 1]])
+        shape = gpd.GeoDataFrame(geometry=[poly])
+        # Create simple data array
+        da = xr.DataArray(
+            data=[[0, 1], [2, 3]],
+            dims=("lon", "lat"),
+            coords={"lon": [0, 1], "lat": [0, 1]},
+        )
+        sub = subset.subset_shape(da, shape=shape)
+        assert sub.notnull().sum() == 3
 
 
 class TestDistance:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #99 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion minor` has been called on this branch
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->

Due to the difference in between rtree-based `geopandas` spatial operations and shapely's `vectorized` operations, `create_mask` is not producing the same results. @aulemahal identified that shapely was solely performing a grid-shape `containing` evaluation. This change introduces a second evaluation for shapes `touching` grid-points.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->

Yes, because the changes that were produced by switching the vectorized version introduced breaking changes. This should revert those changes.

* **Other information:**: <!--(Relevant discussion threads? Outside documentation pages?)-->

~This is presently untested. This should not be merged until tests establish that it is working.~ For more information, see: https://github.com/bird-house/finch/pull/133