### PR TITLE
Esgf test data fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "tests/mini-esgf-data"]
-	path = tests/mini-esgf-data
-	url = https://github.com/roocs/mini-esgf-data.git
 [submodule "tests/xclim-testdata"]
 	path = tests/xclim-testdata
 	url = https://github.com/roocs/xclim-testdata.git

--- a/clisops/utils/tutorial.py
+++ b/clisops/utils/tutorial.py
@@ -40,9 +40,10 @@ def _get(
         url = "/".join((github_url, "raw", branch, fullname.as_posix()))
         LOGGER.info("Fetching remote file: %s" % fullname.as_posix())
         urlretrieve(url, local_file)
+
         try:
             url = "/".join((github_url, "raw", branch, md5name.as_posix()))
-            LOGGER.info("Fetching remote file md5: %s" % fullname.as_posix())
+            LOGGER.info("Fetching remote file md5: %s" % md5name.as_posix())
             urlretrieve(url, md5file)
         except HTTPError as e:
             msg = f"{md5name.as_posix()} not found. Aborting file retrieval."
@@ -50,10 +51,11 @@ def _get(
             raise FileNotFoundError(msg) from e
 
         localmd5 = file_md5_checksum(local_file)
+
         try:
             with open(md5file) as f:
                 remotemd5 = f.read()
-            if localmd5 != remotemd5:
+            if localmd5.strip() != remotemd5.strip():
                 local_file.unlink()
                 msg = """
                     MD5 checksum does not match, try downloading dataset again.

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 from pathlib import Path
+import pytest
 import xarray as xr
 
 from jinja2 import Template
@@ -61,6 +62,14 @@ def cmip6_archive_base():
     return DEFAULT_CMIP6_ARCHIVE_BASE
 
 
+def resolve_files(base_dir, kwargs, file_list):
+    get_file(
+        [os.path.join(base_dir, nc_file) for nc_file in file_list],
+        **kwargs
+    )
+    return os.path.join(kwargs['cache_dir'], kwargs['branch'], base_dir, '*.nc')
+
+
 CMIP5_ARCHIVE_BASE = cmip5_archive_base()
 
 MINI_ESGF_KWARGS = dict(
@@ -74,87 +83,70 @@ MINI_ESGF_KWARGS = dict(
 #    "cmip5/output1/INM/inmcm4/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/*.nc",
 #)
 
-CMIP5_ZOSTOGA = str(
-    get_file(
+@pytest.fixture
+def cmip5_zostoga():
+    return str(get_file(
         'test_data/badc/cmip5/data/cmip5/output1/INM/inmcm4/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/zostoga_Omon_inmcm4_rcp45_r1i1p1_200601-210012.nc',
         **MINI_ESGF_KWARGS
-    )
-)
+    ))
 
 #CMIP5_TAS = os.path.join(
 #    CMIP5_ARCHIVE_BASE,
 #    "cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
 #)
 
-CMIP5_TAS_FILES = [
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_200512-203011.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_209912-212411.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_219912-222411.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_229912-229912.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_203012-205511.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_212412-214911.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_222412-224911.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_205512-208011.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_214912-217411.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_224912-227411.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_208012-209912.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_217412-219911.nc',
-    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_227412-229911.nc'
-]
-
-_ = get_file(
-    [os.path.join('test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas', nc_path)
-        for nc_path in CMIP5_TAS_FILES
-    ],
-    **MINI_ESGF_KWARGS
-)
-
-CMIP5_TAS = os.path.join(
-    MINI_ESGF_CACHE_DIR,
-    'master/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc'
-)
+@pytest.fixture
+def cmip5_tas():
+    return resolve_files(
+        'test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas',
+        MINI_ESGF_KWARGS,
+        ['tas_Amon_HadGEM2-ES_rcp85_r1i1p1_200512-203011.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_209912-212411.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_219912-222411.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_229912-229912.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_203012-205511.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_212412-214911.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_222412-224911.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_205512-208011.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_214912-217411.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_224912-227411.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_208012-209912.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_217412-219911.nc',
+         'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_227412-229911.nc']
+    )
 
 #CMIP5_RH = os.path.join(
 #    CMIP5_ARCHIVE_BASE,
 #    "cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh/*.nc",
 #)
 
-CMIP5_RH_FILES = [
-    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_185912-188411.nc',
-    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_190912-193411.nc',
-    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_195912-198411.nc',
-    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_188412-190911.nc',
-    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_193412-195911.nc',
-    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_198412-200511.nc'
-]
+@pytest.fixture
+def cmip5_rh():
+    return resolve_files(
+        'test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh',
+        MINI_ESGF_KWARGS,
+        ['rh_Lmon_HadGEM2-ES_historical_r1i1p1_185912-188411.nc',
+         'rh_Lmon_HadGEM2-ES_historical_r1i1p1_190912-193411.nc',
+         'rh_Lmon_HadGEM2-ES_historical_r1i1p1_195912-198411.nc',
+         'rh_Lmon_HadGEM2-ES_historical_r1i1p1_188412-190911.nc',
+         'rh_Lmon_HadGEM2-ES_historical_r1i1p1_193412-195911.nc',
+         'rh_Lmon_HadGEM2-ES_historical_r1i1p1_198412-200511.nc']
+    )
 
-_ = get_file(
-    [os.path.join('test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh', nc_path)
-        for nc_path in CMIP5_RH_FILES
-    ],
-    **MINI_ESGF_KWARGS
-)
-
-CMIP5_RH = os.path.join(
-    MINI_ESGF_CACHE_DIR,
-    'master/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh/*.nc'
-)
-
-
-CMIP5_TAS_FILE = str(
-    get_file(
+@pytest.fixture
+def cmip5_tas_file():
+    return str(get_file(
         "cmip5/tas_Amon_HadGEM2-ES_rcp85_r1i1p1_200512-203011.nc",
         branch="add_cmip5_hadgem",  # This will be removed once the branch is merged into "main"
-    )
-)
+    ))
 
 CMIP6_ARCHIVE_BASE = cmip6_archive_base()
 
-CMIP6_O3 = str(
-    get_file(
+@pytest.fixture
+def cmip6_o3():
+    return = str(get_file(
         "cmip6/o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.nc",
-    )
-)
+    ))
 
 #CMIP6_RLDS = os.path.join(
 #    CMIP6_ARCHIVE_BASE,
@@ -162,44 +154,36 @@ CMIP6_O3 = str(
 #    "rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc",
 #)
 
-CMIP6_RLDS = str(
-    get_file(
+@pytest.fixture
+def cmip6_rlds():
+    return str(get_file(
         'test_data/badc/cmip6/data/CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803/rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc',
         **MINI_ESGF_KWARGS
-    )
-)
+    ))
 
-CMIP6_SICONC = str(
-    get_file(
+@pytest.fixture
+def cmip6_siconc():
+    return str(get_file(
         'test_data/badc/cmip6/data/CMIP6/CMIP/NCAR/CESM2/historical/r1i1p1f1/SImon/siconc/gn/latest/siconc_SImon_CESM2_historical_r1i1p1f1_gn_185001-201412.nc',
         **MINI_ESGF_KWARGS
+    ))
+
+@pytest.fixture
+def c3s_cordex_psl():
+    return resolve_files(
+        'test_data/group_workspaces/jasmin2/cp4cds1/vol1/data/c3s-cordex/output/EUR-11/IPSL/MOHC-HadGEM2-ES/rcp85/r1i1p1/IPSL-WRF381P/v1/day/psl/v20190212',
+        MINI_ESGF_KWARGS,
+        ['psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20060101-20101231.nc',
+         'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20510101-20601231.nc',
+         'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20110101-20201231.nc',
+         'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20610101-20701231.nc',
+         'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20210101-20301231.nc',
+         'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20710101-20801231.nc',
+         'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20310101-20401231.nc',
+         'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20810101-20901231.nc',
+         'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20410101-20501231.nc',
+         'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20910101-20991201.nc']
     )
-)
-
-C3S_CORDEX_PSL_FILES = [
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20060101-20101231.nc',
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20510101-20601231.nc',
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20110101-20201231.nc',
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20610101-20701231.nc',
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20210101-20301231.nc',
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20710101-20801231.nc',
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20310101-20401231.nc',
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20810101-20901231.nc',
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20410101-20501231.nc',
-    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20910101-20991201.nc'
-]
-
-_ = get_file(
-    [os.path.join('test_data/group_workspaces/jasmin2/cp4cds1/vol1/data/c3s-cordex/output/EUR-11/IPSL/MOHC-HadGEM2-ES/rcp85/r1i1p1/IPSL-WRF381P/v1/day/psl/v20190212', nc_path)
-        for nc_path in C3S_CORDEX_PSL_FILES
-    ],
-    **MINI_ESGF_KWARGS
-)
-
-C3S_CORDEX_PSL = os.path.join(
-    MINI_ESGF_CACHE_DIR,
-    'master/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data/c3s-cordex/output/EUR-11/IPSL/MOHC-HadGEM2-ES/rcp85/r1i1p1/IPSL-WRF381P/v1/day/psl/v20190212/*.nc'
-)
 
 C3S_CMIP5_TSICE = os.path.join(
     REAL_C3S_CMIP5_ARCHIVE_BASE,

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,5 +1,7 @@
 import os
 import tempfile
+from pathlib import Path
+import xarray as xr
 
 from jinja2 import Template
 
@@ -17,6 +19,7 @@ DEFAULT_CMIP6_ARCHIVE_BASE = os.path.join(
 
 # This is now only required for json files
 XCLIM_TESTS_DATA = os.path.join(TESTS_HOME, "xclim-testdata/testdata")
+MINI_ESGF_CACHE_DIR = Path.home() / ".mini-esgf-data"
 
 
 def write_roocs_cfg():
@@ -60,20 +63,83 @@ def cmip6_archive_base():
 
 CMIP5_ARCHIVE_BASE = cmip5_archive_base()
 
-CMIP5_ZOSTOGA = os.path.join(
-    CMIP5_ARCHIVE_BASE,
-    "cmip5/output1/INM/inmcm4/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/*.nc",
+MINI_ESGF_KWARGS = dict(
+    github_url = 'https://github.com/roocs/mini-esgf-data',
+    branch = 'master',
+    cache_dir = MINI_ESGF_CACHE_DIR
+)
+
+#CMIP5_ZOSTOGA = os.path.join(
+#    CMIP5_ARCHIVE_BASE,
+#    "cmip5/output1/INM/inmcm4/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/*.nc",
+#)
+
+CMIP5_ZOSTOGA = str(
+    get_file(
+        'test_data/badc/cmip5/data/cmip5/output1/INM/inmcm4/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/zostoga_Omon_inmcm4_rcp45_r1i1p1_200601-210012.nc',
+        **MINI_ESGF_KWARGS
+    )
+)
+
+#CMIP5_TAS = os.path.join(
+#    CMIP5_ARCHIVE_BASE,
+#    "cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
+#)
+
+CMIP5_TAS_FILES = [
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_200512-203011.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_209912-212411.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_219912-222411.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_229912-229912.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_203012-205511.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_212412-214911.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_222412-224911.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_205512-208011.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_214912-217411.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_224912-227411.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_208012-209912.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_217412-219911.nc',
+    'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_227412-229911.nc'
+]
+
+_ = get_file(
+    [os.path.join('test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas', nc_path)
+        for nc_path in CMIP5_TAS_FILES
+    ],
+    **MINI_ESGF_KWARGS
 )
 
 CMIP5_TAS = os.path.join(
-    CMIP5_ARCHIVE_BASE,
-    "cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
+    MINI_ESGF_CACHE_DIR,
+    'master/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc'
+)
+
+#CMIP5_RH = os.path.join(
+#    CMIP5_ARCHIVE_BASE,
+#    "cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh/*.nc",
+#)
+
+CMIP5_RH_FILES = [
+    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_185912-188411.nc',
+    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_190912-193411.nc',
+    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_195912-198411.nc',
+    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_188412-190911.nc',
+    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_193412-195911.nc',
+    'rh_Lmon_HadGEM2-ES_historical_r1i1p1_198412-200511.nc'
+]
+
+_ = get_file(
+    [os.path.join('test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh', nc_path)
+        for nc_path in CMIP5_RH_FILES
+    ],
+    **MINI_ESGF_KWARGS
 )
 
 CMIP5_RH = os.path.join(
-    CMIP5_ARCHIVE_BASE,
-    "cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh/*.nc",
+    MINI_ESGF_CACHE_DIR,
+    'master/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh/*.nc'
 )
+
 
 CMIP5_TAS_FILE = str(
     get_file(
@@ -90,10 +156,17 @@ CMIP6_O3 = str(
     )
 )
 
-CMIP6_RLDS = os.path.join(
-    CMIP6_ARCHIVE_BASE,
-    "CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803",
-    "rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc",
+#CMIP6_RLDS = os.path.join(
+#    CMIP6_ARCHIVE_BASE,
+#    "CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803",
+#    "rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc",
+#)
+
+CMIP6_RLDS = str(
+    get_file(
+        'test_data/badc/cmip6/data/CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803/rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc',
+        **MINI_ESGF_KWARGS
+    )
 )
 
 C3S_CMIP5_TSICE = os.path.join(

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 from pathlib import Path
 import pytest
-import xarray as xr
 
 from jinja2 import Template
 
@@ -78,10 +77,6 @@ MINI_ESGF_KWARGS = dict(
     cache_dir = MINI_ESGF_CACHE_DIR
 )
 
-#CMIP5_ZOSTOGA = os.path.join(
-#    CMIP5_ARCHIVE_BASE,
-#    "cmip5/output1/INM/inmcm4/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/*.nc",
-#)
 
 @pytest.fixture
 def cmip5_zostoga():
@@ -90,10 +85,6 @@ def cmip5_zostoga():
         **MINI_ESGF_KWARGS
     ))
 
-#CMIP5_TAS = os.path.join(
-#    CMIP5_ARCHIVE_BASE,
-#    "cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
-#)
 
 @pytest.fixture
 def cmip5_tas():
@@ -115,10 +106,6 @@ def cmip5_tas():
          'tas_Amon_HadGEM2-ES_rcp85_r1i1p1_227412-229911.nc']
     )
 
-#CMIP5_RH = os.path.join(
-#    CMIP5_ARCHIVE_BASE,
-#    "cmip5/output1/MOHC/HadGEM2-ES/historical/mon/land/Lmon/r1i1p1/latest/rh/*.nc",
-#)
 
 @pytest.fixture
 def cmip5_rh():
@@ -133,6 +120,7 @@ def cmip5_rh():
          'rh_Lmon_HadGEM2-ES_historical_r1i1p1_198412-200511.nc']
     )
 
+
 @pytest.fixture
 def cmip5_tas_file():
     return str(get_file(
@@ -142,17 +130,13 @@ def cmip5_tas_file():
 
 CMIP6_ARCHIVE_BASE = cmip6_archive_base()
 
+
 @pytest.fixture
 def cmip6_o3():
-    return = str(get_file(
+    return str(get_file(
         "cmip6/o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.nc",
     ))
 
-#CMIP6_RLDS = os.path.join(
-#    CMIP6_ARCHIVE_BASE,
-#    "CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803",
-#    "rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc",
-#)
 
 @pytest.fixture
 def cmip6_rlds():
@@ -161,12 +145,14 @@ def cmip6_rlds():
         **MINI_ESGF_KWARGS
     ))
 
+
 @pytest.fixture
 def cmip6_siconc():
     return str(get_file(
         'test_data/badc/cmip6/data/CMIP6/CMIP/NCAR/CESM2/historical/r1i1p1f1/SImon/siconc/gn/latest/siconc_SImon_CESM2_historical_r1i1p1f1_gn_185001-201412.nc',
         **MINI_ESGF_KWARGS
     ))
+
 
 @pytest.fixture
 def c3s_cordex_psl():
@@ -184,6 +170,7 @@ def c3s_cordex_psl():
          'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20410101-20501231.nc',
          'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20910101-20991201.nc']
     )
+
 
 C3S_CMIP5_TSICE = os.path.join(
     REAL_C3S_CMIP5_ARCHIVE_BASE,

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -169,6 +169,38 @@ CMIP6_RLDS = str(
     )
 )
 
+CMIP6_SICONC = str(
+    get_file(
+        'test_data/badc/cmip6/data/CMIP6/CMIP/NCAR/CESM2/historical/r1i1p1f1/SImon/siconc/gn/latest/siconc_SImon_CESM2_historical_r1i1p1f1_gn_185001-201412.nc',
+        **MINI_ESGF_KWARGS
+    )
+)
+
+C3S_CORDEX_PSL_FILES = [
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20060101-20101231.nc',
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20510101-20601231.nc',
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20110101-20201231.nc',
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20610101-20701231.nc',
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20210101-20301231.nc',
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20710101-20801231.nc',
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20310101-20401231.nc',
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20810101-20901231.nc',
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20410101-20501231.nc',
+    'psl_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20910101-20991201.nc'
+]
+
+_ = get_file(
+    [os.path.join('test_data/group_workspaces/jasmin2/cp4cds1/vol1/data/c3s-cordex/output/EUR-11/IPSL/MOHC-HadGEM2-ES/rcp85/r1i1p1/IPSL-WRF381P/v1/day/psl/v20190212', nc_path)
+        for nc_path in C3S_CORDEX_PSL_FILES
+    ],
+    **MINI_ESGF_KWARGS
+)
+
+C3S_CORDEX_PSL = os.path.join(
+    MINI_ESGF_CACHE_DIR,
+    'master/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data/c3s-cordex/output/EUR-11/IPSL/MOHC-HadGEM2-ES/rcp85/r1i1p1/IPSL-WRF381P/v1/day/psl/v20190212/*.nc'
+)
+
 C3S_CMIP5_TSICE = os.path.join(
     REAL_C3S_CMIP5_ARCHIVE_BASE,
     "c3s-cmip5/output1/NCC/NorESM1-ME/rcp60/mon/seaIce/OImon/r1i1p1/tsice/v20120614/*.nc",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from tests._common import write_roocs_cfg
+from tests._common import *
 
 write_roocs_cfg()
 

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -19,12 +19,6 @@ from clisops.utils.output_utils import _format_time, get_output, get_time_slices
 from .._common import (
     C3S_CMIP5_TOS,
     C3S_CMIP5_TSICE,
-    CMIP5_RH,
-    CMIP5_TAS,
-    CMIP5_TAS_FILE,
-    CMIP5_ZOSTOGA,
-    CMIP6_O3,
-    CMIP6_RLDS,
 )
 
 
@@ -36,10 +30,10 @@ def _load_ds(fpath):
     return xr.open_mfdataset(fpath)
 
 
-def test_subset_no_params(tmpdir):
+def test_subset_no_params(cmip5_tas_file, tmpdir):
     """ Test subset without area param."""
     result = subset(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         output_dir=tmpdir,
         output_type="nc",
         file_namer="simple",
@@ -47,10 +41,10 @@ def test_subset_no_params(tmpdir):
     _check_output_nc(result)
 
 
-def test_subset_time(tmpdir):
+def test_subset_time(cmip5_tas_file, tmpdir):
     """ Tests clisops subset function with a time subset."""
     result = subset(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         time=("2005-01-01T00:00:00", "2020-12-30T00:00:00"),
         area=(0, -90.0, 360.0, 90.0),
         output_dir=tmpdir,
@@ -60,7 +54,7 @@ def test_subset_time(tmpdir):
     _check_output_nc(result)
 
 
-def test_subset_args_as_parameter_classes(tmpdir):
+def test_subset_args_as_parameter_classes(cmip5_tas_file, tmpdir):
     """Tests clisops subset function with a time subset
     with the arguments as parameter classes from roocs-utils."""
 
@@ -68,7 +62,7 @@ def test_subset_args_as_parameter_classes(tmpdir):
     area = area_parameter.AreaParameter((0, -90.0, 360.0, 90.0))
 
     result = subset(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         time=time,
         area=area,
         output_dir=tmpdir,
@@ -78,11 +72,11 @@ def test_subset_args_as_parameter_classes(tmpdir):
     _check_output_nc(result)
 
 
-def test_subset_invalid_time(tmpdir):
+def test_subset_invalid_time(cmip5_tas_file, tmpdir):
     """ Tests subset with invalid time param."""
     with pytest.raises(InvalidParameterValue):
         subset(
-            ds=CMIP5_TAS_FILE,
+            ds=cmip5_tas_file,
             time=("yesterday", "2020-12-30T00:00:00"),
             area=(0, -90.0, 360.0, 90.0),
             output_dir=tmpdir,
@@ -112,10 +106,10 @@ def test_subset_no_ds(tmpdir):
         )
 
 
-def test_subset_area_simple_file_name(tmpdir):
+def test_subset_area_simple_file_name(cmip5_tas_file, tmpdir):
     """ Tests clisops subset function with a area subset (simple file name)."""
     result = subset(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         area=(0.0, 10.0, 10.0, 65.0),
         output_dir=tmpdir,
         output_type="nc",
@@ -124,10 +118,10 @@ def test_subset_area_simple_file_name(tmpdir):
     _check_output_nc(result)
 
 
-def test_subset_area_project_file_name(tmpdir):
+def test_subset_area_project_file_name(cmip5_tas_file, tmpdir):
     """ Tests clisops subset function with a area subset (derived file name)."""
     result = subset(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         area=(0.0, 10.0, 10.0, 65.0),
         output_dir=tmpdir,
         output_type="nc",
@@ -136,21 +130,21 @@ def test_subset_area_project_file_name(tmpdir):
     _check_output_nc(result, "tas_mon_HadGEM2-ES_rcp85_r1i1p1_20051216-20301116.nc")
 
 
-def test_subset_invalid_area(tmpdir):
+def test_subset_invalid_area(cmip5_tas_file, tmpdir):
     """ Tests subset with invalid area param."""
     with pytest.raises(InvalidParameterValue):
         subset(
-            ds=CMIP5_TAS_FILE,
+            ds=cmip5_tas_file,
             area=("zero", 49.0, 10.0, 65.0),
             output_dir=tmpdir,
         )
 
 
 @pytest.mark.xfail(reason="cross the 0 degree meridian not implemented.")
-def test_subset_area_with_meridian(tmpdir):
+def test_subset_area_with_meridian(cmip5_tas_file, tmpdir):
     """ Tests clisops subset function with a area subset."""
     result = subset(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         area=(-10.0, 49.0, 10.0, 65.0),
         output_dir=tmpdir,
         output_type="nc",
@@ -159,10 +153,10 @@ def test_subset_area_with_meridian(tmpdir):
     _check_output_nc(result)
 
 
-def test_subset_with_time_and_area(tmpdir):
+def test_subset_with_time_and_area(cmip5_tas_file, tmpdir):
     """ Tests clisops subset function with time, area, level subsets."""
     result = subset(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         time=("2019-01-01T00:00:00", "2020-12-30T00:00:00"),
         area=(0.0, 0.0, 10.0, 65.0),
         output_dir=tmpdir,
@@ -172,10 +166,10 @@ def test_subset_with_time_and_area(tmpdir):
     _check_output_nc(result)
 
 
-def test_subset_with_multiple_files_tas(tmpdir):
+def test_subset_with_multiple_files_tas(cmip5_tas, tmpdir):
     """ Tests with multiple tas files"""
     result = subset(
-        ds=CMIP5_TAS,
+        ds=cmip5_tas,
         time=("2001-01-01T00:00:00", "2020-12-30T00:00:00"),
         area=(0.0, 0.0, 10.0, 65.0),
         output_dir=tmpdir,
@@ -185,10 +179,10 @@ def test_subset_with_multiple_files_tas(tmpdir):
     _check_output_nc(result)
 
 
-def test_subset_with_multiple_files_zostoga(tmpdir):
+def test_subset_with_multiple_files_zostoga(cmip5_zostoga, tmpdir):
     """ Tests with multiple zostoga files"""
     result = subset(
-        ds=CMIP5_ZOSTOGA,
+        ds=cmip5_zostoga,
         time=("2000-01-01T00:00:00", "2020-12-30T00:00:00"),
         output_dir=tmpdir,
         output_type="nc",
@@ -197,10 +191,10 @@ def test_subset_with_multiple_files_zostoga(tmpdir):
     _check_output_nc(result)
 
 
-def test_subset_with_multiple_files_rh(tmpdir):
+def test_subset_with_multiple_files_rh(cmip5_rh, tmpdir):
     """ Tests with multiple rh files"""
     result = subset(
-        ds=CMIP5_RH,
+        ds=cmip5_rh,
         time=("2005-01-01T00:00:00", "2020-12-30T00:00:00"),
         area=(0, -90.0, 360.0, 90.0),
         output_dir=tmpdir,
@@ -222,7 +216,7 @@ def test_subset_with_tas_series(tmpdir, tas_series):
     _check_output_nc(result)
 
 
-def test_time_slices_in_subset_tas():
+def test_time_slices_in_subset_tas(cmip5_tas):
     start_time, end_time = "2001-01-01T00:00:00", "2200-12-30T00:00:00"
 
     time_slices = [
@@ -239,7 +233,7 @@ def test_time_slices_in_subset_tas():
     CONFIG["clisops:write"]["file_size_limit"] = temp_max_file_size
 
     outputs = subset(
-        ds=CMIP5_TAS,
+        ds=cmip5_tas,
         time=(start_time, end_time),
         area=(0.0, 5.0, 50.0, 90.0),
         output_type="xarray",
@@ -257,7 +251,7 @@ def test_time_slices_in_subset_tas():
         count += 1
 
 
-def test_time_slices_in_subset_rh():
+def test_time_slices_in_subset_rh(cmip5_rh):
     start_time, end_time = "2001-01-01T00:00:00", "2200-12-30T00:00:00"
 
     time_slices = [
@@ -270,7 +264,7 @@ def test_time_slices_in_subset_rh():
     temp_max_file_size = "10KB"
     CONFIG["clisops:write"]["file_size_limit"] = temp_max_file_size
     outputs = subset(
-        ds=CMIP5_RH,
+        ds=cmip5_rh,
         time=(start_time, end_time),
         area=(0.0, 5.0, 50.0, 90.0),
         output_type="xarray",
@@ -289,11 +283,11 @@ def test_time_slices_in_subset_rh():
 
 
 # area can be a few degrees out
-def test_area_within_area_subset():
+def test_area_within_area_subset(cmip5_tas):
     area = (0.0, 10.0, 175.0, 90.0)
 
     outputs = subset(
-        ds=CMIP5_TAS,
+        ds=cmip5_tas,
         time=("2001-01-01T00:00:00", "2200-12-30T00:00:00"),
         area=area,
         output_type="xarray",
@@ -305,11 +299,11 @@ def test_area_within_area_subset():
     assert area[1] <= ds.lat.data <= area[3]
 
 
-def test_area_within_area_subset_cmip6():
+def test_area_within_area_subset_cmip6(cmip6_rlds):
     area = (100.0, 10.0, 300.0, 90.0)
 
     outputs = subset(
-        ds=CMIP6_RLDS,
+        ds=cmip6_rlds,
         time=("2001-01-01T00:00:00", "2002-12-30T00:00:00"),
         area=area,
         output_type="xarray",
@@ -323,7 +317,7 @@ def test_area_within_area_subset_cmip6():
     assert np.isclose(ds.lat.data[0], 36.76056)
 
 
-def test_subset_with_lat_lon_single_values():
+def test_subset_with_lat_lon_single_values(cmip6_rlds):
     """Creates subset where lat and lon only have one value. Then
     subsets that. This tests that the `lat_bnds` and `lon_bnds`
     are not being reversed by the `_check_desc_coords` function in
@@ -332,7 +326,7 @@ def test_subset_with_lat_lon_single_values():
     area = (100.0, 10.0, 300.0, 90.0)
 
     outputs = subset(
-        ds=CMIP6_RLDS,
+        ds=cmip6_rlds,
         time=("2001-01-01T00:00:00", "2002-12-30T00:00:00"),
         area=area,
         output_type="xarray",
@@ -352,7 +346,7 @@ def test_subset_with_lat_lon_single_values():
     assert len(ds2.lon) == 1
 
 
-def test_area_within_area_subset_chunked():
+def test_area_within_area_subset_chunked(cmip5_tas):
 
     start_time, end_time = "2001-01-01T00:00:00", "2200-12-30T00:00:00"
     area = (0.0, 10.0, 175.0, 90.0)
@@ -361,7 +355,7 @@ def test_area_within_area_subset_chunked():
     temp_max_file_size = "10KB"
     CONFIG["clisops:write"]["file_size_limit"] = temp_max_file_size
     outputs = subset(
-        ds=CMIP5_TAS,
+        ds=cmip5_tas,
         time=(start_time, end_time),
         area=area,
         output_type="xarray",
@@ -374,20 +368,20 @@ def test_area_within_area_subset_chunked():
         assert area[1] <= ds.lat.data <= area[3]
 
 
-def test_subset_level(tmpdir):
+def test_subset_level(cmip6_o3, tmpdir):
     """ Tests clisops subset function with a level subset."""
     # Levels are: 100000, ..., 100
-    ds = _load_ds(CMIP6_O3)
+    ds = _load_ds(cmip6_o3)
 
-    result1 = subset(ds=CMIP6_O3, level="100000/100", output_type="xarray")
+    result1 = subset(ds=cmip6_o3, level="100000/100", output_type="xarray")
 
     np.testing.assert_array_equal(result1[0].o3.values, ds.o3.values)
 
-    result2 = subset(ds=CMIP6_O3, level="100/100", output_type="xarray")
+    result2 = subset(ds=cmip6_o3, level="100/100", output_type="xarray")
 
     np.testing.assert_array_equal(result2[0].o3.shape, (1200, 1, 2, 3))
 
-    result3 = subset(ds=CMIP6_O3, level="101/-23.234", output_type="xarray")
+    result3 = subset(ds=cmip6_o3, level="101/-23.234", output_type="xarray")
 
     np.testing.assert_array_equal(result3[0].o3.values, result2[0].o3.values)
 

--- a/tests/ops/test_xarray_mean.py
+++ b/tests/ops/test_xarray_mean.py
@@ -1,8 +1,6 @@
 import numpy as np
 import xarray as xr
 
-from .._common import CMIP5_TAS
-
 nan = np.nan
 
 
@@ -28,9 +26,9 @@ def test_xarray_da_mean_skipna_none():
     assert mean == 10
 
 
-def test_xarray_da_mean_keep_attrs_true():
+def test_xarray_da_mean_keep_attrs_true(cmip5_tas):
     ds = xr.open_mfdataset(
-        CMIP5_TAS,
+        cmip5_tas,
         combine="by_coords",
         use_cftime=True,
     )
@@ -41,9 +39,9 @@ def test_xarray_da_mean_keep_attrs_true():
     assert ds.attrs == ds_mean.attrs
 
 
-def test_xarray_da_mean_keep_attrs_false():
+def test_xarray_da_mean_keep_attrs_false(cmip5_tas):
     ds = xr.open_mfdataset(
-        CMIP5_TAS,
+        cmip5_tas,
         combine="by_coords",
         use_cftime=True,
     )

--- a/tests/ops/test_xarray_mean.py
+++ b/tests/ops/test_xarray_mean.py
@@ -1,6 +1,8 @@
 import numpy as np
 import xarray as xr
 
+from .._common import CMIP5_TAS
+
 nan = np.nan
 
 
@@ -28,8 +30,7 @@ def test_xarray_da_mean_skipna_none():
 
 def test_xarray_da_mean_keep_attrs_true():
     ds = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/"
-        "atmos/Amon/r1i1p1/latest/tas/*.nc",
+        CMIP5_TAS,
         combine="by_coords",
         use_cftime=True,
     )
@@ -42,8 +43,7 @@ def test_xarray_da_mean_keep_attrs_true():
 
 def test_xarray_da_mean_keep_attrs_false():
     ds = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/"
-        "atmos/Amon/r1i1p1/latest/tas/*.nc",
+        CMIP5_TAS,
         combine="by_coords",
         use_cftime=True,
     )

--- a/tests/test_file_namers.py
+++ b/tests/test_file_namers.py
@@ -7,7 +7,7 @@ from clisops import CONFIG
 from clisops.ops.subset import subset
 from clisops.utils.file_namers import get_file_namer
 
-from ._common import CMIP5_TAS
+from ._common import CMIP5_TAS, CMIP6_SICONC, C3S_CORDEX_PSL
 
 
 def test_SimpleFileNamer():
@@ -74,8 +74,7 @@ def test_StandardFileNamer_cmip5():
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES"
-        "/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
+        CMIP5_TAS,
         use_cftime=True,
         combine="by_coords",
     )
@@ -91,8 +90,7 @@ def test_StandardFileNamer_cmip5_use_default_attr_names():
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC"
-        "/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
+        CMIP5_TAS,
         use_cftime=True,
         combine="by_coords",
     )
@@ -109,8 +107,7 @@ def test_StandardFileNamer_cmip6():
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/badc/cmip6/data/CMIP6/CMIP/NCAR/CESM2/historical/r1i1p1f1/SImon"
-        "/siconc/gn/latest/*.nc",
+        CMIP6_SICONC,
         use_cftime=True,
         combine="by_coords",
     )
@@ -126,8 +123,7 @@ def test_StandardFileNamer_cmip6_use_default_attr_names():
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/badc/cmip6/data/CMIP6/CMIP/NCAR/CESM2/historical/r1i1p1f1/SImon"
-        "/siconc/gn/latest/*.nc",
+        CMIP6_SICONC,
         use_cftime=True,
         combine="by_coords",
     )
@@ -151,8 +147,7 @@ def test_StandardFileNamer_c3s_cordex():
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data/c3s-cordex/output/EUR-11"
-        "/IPSL/MOHC-HadGEM2-ES/rcp85/r1i1p1/IPSL-WRF381P/v1/day/psl/v20190212/*.nc",
+        C3S_CORDEX_PSL,
         use_cftime=True,
         combine="by_coords",
     )
@@ -177,8 +172,7 @@ def test_StandardFileNamer_c3s_cordex_use_default_attr_names():
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        "tests/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data/c3s-cordex/output/EUR-11"
-        "/IPSL/MOHC-HadGEM2-ES/rcp85/r1i1p1/IPSL-WRF381P/v1/day/psl/v20190212/*.nc",
+        C3S_CORDEX_PSL,
         use_cftime=True,
         combine="by_coords",
     )

--- a/tests/test_file_namers.py
+++ b/tests/test_file_namers.py
@@ -7,8 +7,6 @@ from clisops import CONFIG
 from clisops.ops.subset import subset
 from clisops.utils.file_namers import get_file_namer
 
-from ._common import CMIP5_TAS, CMIP6_SICONC, C3S_CORDEX_PSL
-
 
 def test_SimpleFileNamer():
     s = get_file_namer("simple")()
@@ -33,7 +31,7 @@ def test_SimpleFileNamer_no_fmt():
             s.get_file_name(*args)
 
 
-def test_SimpleFileNamer_with_chunking(tmpdir):
+def test_SimpleFileNamer_with_chunking(cmip5_tas, tmpdir):
     start_time, end_time = "2001-01-01T00:00:00", "2200-12-30T00:00:00"
     area = (0.0, 10.0, 175.0, 90.0)
 
@@ -41,7 +39,7 @@ def test_SimpleFileNamer_with_chunking(tmpdir):
     temp_max_file_size = "10KB"
     CONFIG["clisops:write"]["file_size_limit"] = temp_max_file_size
     outputs = subset(
-        ds=CMIP5_TAS,
+        ds=cmip5_tas,
         time=(start_time, end_time),
         area=area,
         output_dir=tmpdir,
@@ -70,11 +68,11 @@ def test_StandardFileNamer_no_project_match():
         s.get_file_name(mock_ds)
 
 
-def test_StandardFileNamer_cmip5():
+def test_StandardFileNamer_cmip5(cmip5_tas):
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        CMIP5_TAS,
+        cmip5_tas,
         use_cftime=True,
         combine="by_coords",
     )
@@ -86,11 +84,11 @@ def test_StandardFileNamer_cmip5():
         assert resp == expected
 
 
-def test_StandardFileNamer_cmip5_use_default_attr_names():
+def test_StandardFileNamer_cmip5_use_default_attr_names(cmip5_tas):
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        CMIP5_TAS,
+        cmip5_tas,
         use_cftime=True,
         combine="by_coords",
     )
@@ -103,11 +101,11 @@ def test_StandardFileNamer_cmip5_use_default_attr_names():
         assert resp == expected
 
 
-def test_StandardFileNamer_cmip6():
+def test_StandardFileNamer_cmip6(cmip6_siconc):
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        CMIP6_SICONC,
+        cmip6_siconc,
         use_cftime=True,
         combine="by_coords",
     )
@@ -119,11 +117,11 @@ def test_StandardFileNamer_cmip6():
         assert resp == expected
 
 
-def test_StandardFileNamer_cmip6_use_default_attr_names():
+def test_StandardFileNamer_cmip6_use_default_attr_names(cmip6_siconc):
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        CMIP6_SICONC,
+        cmip6_siconc,
         use_cftime=True,
         combine="by_coords",
     )
@@ -143,11 +141,11 @@ def test_StandardFileNamer_cmip6_use_default_attr_names():
     condition="platform.system() == 'Windows'",
     reason="Git modules not working on Windows",
 )
-def test_StandardFileNamer_c3s_cordex():
+def test_StandardFileNamer_c3s_cordex(c3s_cordex_psl):
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        C3S_CORDEX_PSL,
+        c3s_cordex_psl,
         use_cftime=True,
         combine="by_coords",
     )
@@ -168,11 +166,11 @@ def test_StandardFileNamer_c3s_cordex():
     condition="platform.system() == 'Windows'",
     reason="Git modules not working on Windows",
 )
-def test_StandardFileNamer_c3s_cordex_use_default_attr_names():
+def test_StandardFileNamer_c3s_cordex_use_default_attr_names(c3s_cordex_psl):
     s = get_file_namer("standard")()
 
     _ds = xr.open_mfdataset(
-        C3S_CORDEX_PSL,
+        c3s_cordex_psl,
         use_cftime=True,
         combine="by_coords",
     )

--- a/tests/test_output_utils.py
+++ b/tests/test_output_utils.py
@@ -5,8 +5,6 @@ import xarray as xr
 from clisops.utils.common import expand_wildcards
 from clisops.utils.output_utils import get_time_slices
 
-from ._common import CMIP5_TAS
-
 
 def _open(coll):
     if isinstance(coll, (str, Path)):
@@ -18,9 +16,9 @@ def _open(coll):
     return ds
 
 
-def test_get_time_slices_single_slice():
+def test_get_time_slices_single_slice(cmip5_tas):
 
-    tas = _open(CMIP5_TAS)
+    tas = _open(cmip5_tas)
 
     test_data = [
         (
@@ -44,9 +42,9 @@ def test_get_time_slices_single_slice():
         assert resp[0] == slices
 
 
-def test_get_time_slices_multiple_slices():
+def test_get_time_slices_multiple_slices(cmip5_tas):
 
-    tas = _open(CMIP5_TAS)
+    tas = _open(cmip5_tas)
 
     test_data = [
         (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,6 @@ from roocs_utils.exceptions import InvalidParameterValue
 
 from clisops import CONFIG, utils
 
-from ._common import CMIP5_TAS_FILE
-
 
 def test_local_config_loads():
     assert "clisops:read" in CONFIG
@@ -19,9 +17,9 @@ def test_dask_env_variables():
     assert os.getenv("OMP_NUM_THREADS") == "1"
 
 
-def test_map_params():
+def test_map_params(cmip5_tas_file):
     args = utils.map_params(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         time=("1999-01-01T00:00:00", "2100-12-30T00:00:00"),
         area=(-5.0, 49.0, 10.0, 65),
         level=(1000.0, 1000.0),
@@ -34,49 +32,49 @@ def test_map_params():
     assert args["lat_bnds"] == (49, 65)
 
 
-def test_map_params_time():
+def test_map_params_time(cmip5_tas_file):
     args = utils.map_params(
-        ds=CMIP5_TAS_FILE, time=("1999-01-01", "2100-12"), area=(0, -90, 360, 90)
+        ds=cmip5_tas_file, time=("1999-01-01", "2100-12"), area=(0, -90, 360, 90)
     )
     assert args["start_date"] == "1999-01-01T00:00:00"
     assert args["end_date"] == "2100-12-30T00:00:00"
 
 
-def test_map_params_invalid_time():
+def test_map_params_invalid_time(cmip5_tas_file):
     with pytest.raises(InvalidParameterValue):
         utils.map_params(
-            ds=CMIP5_TAS_FILE,
+            ds=cmip5_tas_file,
             time=("1999-01-01T00:00:00", "maybe tomorrow"),
             area=(0, -90, 360, 90),
         )
     with pytest.raises(InvalidParameterValue):
-        utils.map_params(ds=CMIP5_TAS_FILE, time=("", "2100"), area=(0, -90, 360, 90))
+        utils.map_params(ds=cmip5_tas_file, time=("", "2100"), area=(0, -90, 360, 90))
 
 
-def test_map_params_area():
+def test_map_params_area(cmip5_tas_file):
     args = utils.map_params(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         area=(0, 10, 50, 60),
     )
     assert args["lon_bnds"] == (0, 50)
     assert args["lat_bnds"] == (10, 60)
     # allow also strings
     args = utils.map_params(
-        ds=CMIP5_TAS_FILE,
+        ds=cmip5_tas_file,
         area=("0", "10", "50", "60"),
     )
     assert args["lon_bnds"] == (0, 50)
     assert args["lat_bnds"] == (10, 60)
 
 
-def test_map_params_invalid_area():
+def test_map_params_invalid_area(cmip5_tas_file):
     with pytest.raises(InvalidParameterValue):
         utils.map_params(
-            ds=CMIP5_TAS_FILE,
+            ds=cmip5_tas_file,
             area=(0, 10, 50),
         )
     with pytest.raises(InvalidParameterValue):
         utils.map_params(
-            ds=CMIP5_TAS_FILE,
+            ds=cmip5_tas_file,
             area=("zero", 10, 50, 60),
         )


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #107
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion minor` has been called on this branch
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Tests using esgf data now use `pytest` fixtures, implementing `get_file()`, to cache the relevant data rather than using the `mini-esgf-data` submodule.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No

* **Other information:**: <!--(Relevant discussion threads? Outside documentation pages?)-->
