### PR TITLE
add test to demostrate exception when subsetting with time on a time …

### DIFF
--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -603,3 +603,15 @@ def test_time_invariant_subset_simple_name(load_esgf_test_data, tmpdir):
     )
 
     _check_output_nc(result)
+
+
+def test_time_invariant_subset_with_time(load_esgf_test_data):
+
+    with pytest.raises(AttributeError) as exc:
+        subset(
+            ds=CMIP6_MRSOFC,
+            time=("2005-01-01T00:00:00", "2020-12-30T00:00:00"),
+            area=(5.0, 10.0, 20.0, 65.0),
+            output_type="xarray",
+        )
+    assert str(exc.value) == "'Dataset' object has no attribute 'time'"


### PR DESCRIPTION
…invariant dataset

<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #118 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion minor` has been called on this branch
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Add test to demonstrate that an exception is raised when a time subset is requested on a dataset which doesn't have time as a dimension

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->


* **Other information:**: <!--(Relevant discussion threads? Outside documentation pages?)-->
