### PR TITLE
Fix incorrect longitude values with roll and give ds_roll lon attributes

### DIFF
--- a/clisops/utils/dataset_utils.py
+++ b/clisops/utils/dataset_utils.py
@@ -66,6 +66,11 @@ def check_lon_alignment(ds, lon_bnds):
         else:
             first_element_value = low
             diff, offset = calculate_offset(lon, first_element_value)
+
+            # roll the dataset
             ds_roll = ds.roll(shifts={f"{lon.name}": offset}, roll_coords=False)
+
+            # assign longitude to match the roll and copy attrs
             ds_roll.coords[lon.name] = ds_roll.coords[lon.name] + diff
+            ds_roll.coords[lon.name].attrs = ds.coords[lon.name].attrs
             return ds_roll

--- a/clisops/utils/dataset_utils.py
+++ b/clisops/utils/dataset_utils.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 from roocs_utils.xarray_utils.xarray_utils import get_coord_by_type
 
@@ -9,7 +11,7 @@ LOGGER = logging.getLogger(__file__)
 def calculate_offset(lon, first_element_value):
     """
     Calculate the number of elements to roll the dataset by in order to have
-    longitude from -180 to 180 degrees.
+    longitude from within requested bounds.
 
     :param lon: longitude coordinate of xarray dataset.
     :param first_element_value: the value of the first element of the longitude array to roll to.
@@ -18,15 +20,15 @@ def calculate_offset(lon, first_element_value):
     res = lon.values[1] - lon.values[0]
 
     # calculate how many degrees to move by to have lon[0] of rolled subset as lower bound of request
-    diff = first_element_value - lon.values[0]
+    diff = lon.values[0] - first_element_value
 
     # work out how many elements to roll by to roll data by 1 degree
     index = 1 / res
 
     # calculate the corresponding offset needed to change data by diff
-    offset = int(diff * index)
+    offset = int(round(diff * index))
 
-    return diff, offset
+    return offset
 
 
 def check_lon_alignment(ds, lon_bnds):
@@ -65,12 +67,20 @@ def check_lon_alignment(ds, lon_bnds):
         # roll the dataset and reassign the longitude values
         else:
             first_element_value = low
-            diff, offset = calculate_offset(lon, first_element_value)
+            offset = calculate_offset(lon, first_element_value)
 
             # roll the dataset
-            ds_roll = ds.roll(shifts={f"{lon.name}": offset}, roll_coords=False)
+            ds_roll = ds.roll(shifts={f"{lon.name}": offset}, roll_coords=True)
 
             # assign longitude to match the roll and copy attrs
-            ds_roll.coords[lon.name] = ds_roll.coords[lon.name] + diff
+            lon_vals = ds_roll.coords[lon.name].values
+
+            # treat the values differently according to positive/negative offset
+            if offset < 0:
+                lon_vals[offset:] = lon_vals[offset:] % 360
+            else:
+                lon_vals[:offset] = lon_vals[:offset] % -360
+
+            ds_roll.coords[lon.name] = lon_vals
             ds_roll.coords[lon.name].attrs = ds.coords[lon.name].attrs
             return ds_roll

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -732,24 +732,48 @@ def test_300_60_cross(tmpdir):
 
 
 @pytest.mark.skipif(Path("/badc").is_dir() is False, reason="data not available")
-def test_check_lon_alignment_rolled():
+class TestLonAlignmentRolled:
+
     ds = _load_ds(
         "/badc/cmip6/data/CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803/"
         "rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
     )
 
-    area = (-50.0, -90.0, 100.0, 90.0)
+    def test_roll_positive_1(self):
 
-    result = subset(
-        ds=ds,
-        area=area,
-        output_type="xarray",
-    )
+        area = (-50.0, -90.0, 100.0, 90.0)
 
-    assert result[0].lon.attrs == ds.lon.attrs
+        result = subset(
+            ds=self.ds,
+            area=area,
+            output_type="xarray",
+        )
 
-    assert area[0] <= all(result[0].lon.data) <= area[2]
-    assert area[1] <= all(result[0].lat.data) <= area[3]
+        assert result[0].lon.attrs == self.ds.lon.attrs
+
+        assert area[0] <= all(result[0].lon.values) <= area[2]
+        assert area[1] <= all(result[0].lat.values) <= area[3]
+
+        # check array contains expected values
+        assert np.array_equal(result[0].lon.values, np.arange(-50, 102.5, 2.5))
+
+    def test_roll_positive_2(self):
+
+        area = (-180.0, -90.0, 120.0, 90.0)
+
+        result = subset(
+            ds=self.ds,
+            area=area,
+            output_type="xarray",
+        )
+
+        assert result[0].lon.attrs == self.ds.lon.attrs
+
+        assert area[0] <= all(result[0].lon.values) <= area[2]
+        assert area[1] <= all(result[0].lat.values) <= area[3]
+
+        # check array contains expected values
+        assert np.array_equal(result[0].lon.values, np.arange(-180, 122.5, 2.5))
 
 
 @pytest.mark.skipif(Path("/badc").is_dir() is False, reason="data not available")

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -732,48 +732,49 @@ def test_300_60_cross(tmpdir):
 
 
 @pytest.mark.skipif(Path("/badc").is_dir() is False, reason="data not available")
-class TestLonAlignmentRolled:
-
+def test_roll_positive_real_data():
     ds = _load_ds(
         "/badc/cmip6/data/CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803/"
         "rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
     )
 
-    def test_roll_positive_1(self):
+    area = (-50.0, -90.0, 100.0, 90.0)
 
-        area = (-50.0, -90.0, 100.0, 90.0)
+    result = subset(
+        ds=ds,
+        area=area,
+        output_type="xarray",
+    )
 
-        result = subset(
-            ds=self.ds,
-            area=area,
-            output_type="xarray",
-        )
+    assert result[0].lon.attrs == ds.lon.attrs
 
-        assert result[0].lon.attrs == self.ds.lon.attrs
+    assert area[0] <= all(result[0].lon.values) <= area[2]
+    assert area[1] <= all(result[0].lat.values) <= area[3]
 
-        assert area[0] <= all(result[0].lon.values) <= area[2]
-        assert area[1] <= all(result[0].lat.values) <= area[3]
+    # check array contains expected values
+    assert np.array_equal(result[0].lon.values, np.arange(-50, 102.5, 2.5))
 
-        # check array contains expected values
-        assert np.array_equal(result[0].lon.values, np.arange(-50, 102.5, 2.5))
 
-    def test_roll_positive_2(self):
+def test_roll_positive_mini_data():
+    ds = _load_ds(CMIP6_TA)
 
-        area = (-180.0, -90.0, 120.0, 90.0)
+    area = (-180.0, -90.0, 120.0, 90.0)
 
-        result = subset(
-            ds=self.ds,
-            area=area,
-            output_type="xarray",
-        )
+    result = subset(
+        ds=ds,
+        area=area,
+        output_type="xarray",
+    )
 
-        assert result[0].lon.attrs == self.ds.lon.attrs
+    assert result[0].lon.attrs == ds.lon.attrs
 
-        assert area[0] <= all(result[0].lon.values) <= area[2]
-        assert area[1] <= all(result[0].lat.values) <= area[3]
+    assert area[0] <= all(result[0].lon.values) <= area[2]
+    assert area[1] <= all(result[0].lat.values) <= area[3]
 
-        # check array contains expected values
-        assert np.array_equal(result[0].lon.values, np.arange(-180, 122.5, 2.5))
+    # check array contains expected values
+    assert np.array_equal(
+        result[0].lon.values, [-170.15625, -106.875, -43.59375, 0.0, 63.28125]
+    )
 
 
 @pytest.mark.skipif(Path("/badc").is_dir() is False, reason="data not available")

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -28,7 +28,10 @@ def _check_output_nc(result, fname="output_001.nc"):
 
 def _load_ds(fpath):
     if isinstance(fpath, (str, Path)):
-        return xr.open_dataset(fpath)
+        if fpath.endswith("*.nc"):
+            return xr.open_mfdataset(fpath)
+        else:
+            return xr.open_dataset(fpath)
     return xr.open_mfdataset(fpath)
 
 
@@ -742,6 +745,8 @@ def test_check_lon_alignment_rolled():
         area=area,
         output_type="xarray",
     )
+
+    assert result[0].lon.attrs == ds.lon.attrs
 
     assert area[0] <= all(result[0].lon.data) <= area[2]
     assert area[1] <= all(result[0].lat.data) <= area[3]

--- a/tests/test_dataset_roll.py
+++ b/tests/test_dataset_roll.py
@@ -1,0 +1,365 @@
+""" Test the different methods of transforming the longitude coordinates after rolling"""
+
+import numpy as np
+
+
+# calculate the offset in the same way as in dataset_utils
+def calculate_offset(a, bounds):
+    low, high = bounds
+    # get resolution of data
+    res = a[1] - a[0]
+
+    # calculate how many degrees to move by to have lon[0] of rolled subset as lower bound of request
+    diff = a[0] - low
+
+    # work out how many elements to roll by to roll data by 1 degree
+    index = 1 / res
+
+    # calculate the corresponding offset needed to change data by diff
+    # round up to ensure rolling by enough
+    # offset = math.ceil(diff * index)
+    offset = int(round(diff * index))
+
+    return offset
+
+
+def dataset_roll(a, offset, bounds):
+    # roll the dataset
+    low, high = bounds
+    a_roll = np.roll(a, offset)
+
+    if offset < 0:
+        a_new = np.where(
+            np.logical_and(low >= a_roll, a_roll <= -(360 + low)), a_roll, a_roll % 360
+        )  # this doesn't work in all negative offset cases
+    else:
+        a_new = np.where(a_roll < (360 + low), a_roll, a_roll % -360)
+
+    return a_new
+
+
+def dataset_roll_using_offset(a, offset):
+    # roll the dataset
+    a_roll = np.roll(a, offset)
+
+    if offset < 0:
+        a_roll[offset:] = a_roll[offset:] % 360
+    else:
+        a_roll[:offset] = a_roll[:offset] % -360
+
+    return a_roll
+
+
+class TestLonRoll_0_360:
+
+    # offset = 359
+    def test_to_minus_359_0(self):
+        a = np.arange(start=0, stop=360, step=1)
+        bounds = (-359, 0)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-359, stop=1, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-359, stop=1, step=1))
+
+    # offset = 270
+    def test_to_minus_270_to_89(self):
+        a = np.arange(start=0, stop=360, step=1)
+        bounds = (-270, 89)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-270, stop=90, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-270, stop=90, step=1))
+
+    # offset = 180
+    def test_to_minus_180_179(self):
+        a = np.arange(start=0, stop=360, step=1)
+        bounds = (-180, 179)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-180, stop=180, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-180, stop=180, step=1))
+
+    # offset = 90
+    def test_to_minus_90_269(self):
+        a = np.arange(start=0, stop=360, step=1)
+        bounds = (-90, 269)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-90, stop=270, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-90, stop=270, step=1))
+
+    # offset = 0
+    def test_to_0_359(self):
+        a = np.arange(start=0, stop=360, step=1)
+        bounds = (0, 359)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=0, stop=360, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=0, stop=360, step=1))
+
+
+class TestLonRoll_minus_90_270:
+
+    # offset = 269
+    def test_to_minus_359_0(self):
+        a = np.arange(start=-90, stop=270, step=1)
+        bounds = (-359, 0)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-359, stop=1, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-359, stop=1, step=1))
+
+    # offset = 180
+    def test_to_minus_270_to_89(self):
+        a = np.arange(start=-90, stop=270, step=1)
+        bounds = (-270, 89)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-270, stop=90, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-270, stop=90, step=1))
+
+    # offset = 90
+    def test_to_minus_180_179(self):
+        a = np.arange(start=-90, stop=270, step=1)
+        bounds = (-180, 179)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-180, stop=180, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-180, stop=180, step=1))
+
+    # offset = 0
+    def test_to_minus_90_269(self):
+        a = np.arange(start=-90, stop=270, step=1)
+        bounds = (-90, 269)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-90, stop=270, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-90, stop=270, step=1))
+
+    # offset = -90 - FAILS
+    def test_to_0_359(self):
+        a = np.arange(start=-90, stop=270, step=1)
+        bounds = (0, 359)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=0, stop=360, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=0, stop=360, step=1))
+
+
+class TestLonRoll_minus_180_180:
+
+    # offset = 179
+    def test_to_minus_359_0(self):
+        a = np.arange(start=-180, stop=180, step=1)
+        bounds = (-359, 0)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-359, stop=1, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-359, stop=1, step=1))
+
+    # offset = 90
+    def test_to_minus_270_to_89(self):
+        a = np.arange(start=-180, stop=180, step=1)
+        bounds = (-270, 89)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-270, stop=90, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-270, stop=90, step=1))
+
+    # offset = 0
+    def test_to_minus_180_179(self):
+        a = np.arange(start=-180, stop=180, step=1)
+        bounds = (-180, 179)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-180, stop=180, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-180, stop=180, step=1))
+
+    # offset = -90 - FAILS
+    def test_to_minus_90_269(self):
+        a = np.arange(start=-180, stop=180, step=1)
+        bounds = (-90, 269)
+        offset = calculate_offset(a, bounds)
+
+        # a_where = dataset_roll(a, offset, bounds)
+        # assert np.array_equal(a_where, np.arange(start=-90, stop=270, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-90, stop=270, step=1))
+
+    # offset = -180 - FAILS
+    def test_to_0_359(self):
+        a = np.arange(start=-180, stop=180, step=1)
+        bounds = (0, 359)
+        offset = calculate_offset(a, bounds)
+
+        # a_where = dataset_roll(a, offset, bounds)
+        # assert np.array_equal(a_where, np.arange(start=0, stop=360, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=0, stop=360, step=1))
+
+
+class TestLonRoll_minus_270_90:
+
+    # offset = 89
+    def test_to_minus_359_0(self):
+        a = np.arange(start=-270, stop=90, step=1)
+        bounds = (-359, 0)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-359, stop=1, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-359, stop=1, step=1))
+
+    # offset = 0
+    def test_to_minus_270_to_89(self):
+        a = np.arange(start=-270, stop=90, step=1)
+        bounds = (-270, 89)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-270, stop=90, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-270, stop=90, step=1))
+
+    # offset = -90 - fAILS
+    def test_to_minus_180_179(self):
+        a = np.arange(start=-270, stop=90, step=1)
+        bounds = (-180, 179)
+        offset = calculate_offset(a, bounds)
+
+        # a_where = dataset_roll(a, offset, bounds)
+        # assert np.array_equal(a_where, np.arange(start=-180, stop=180, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-180, stop=180, step=1))
+
+    # offset = -180 - FAILS
+    def test_to_minus_90_269(self):
+        a = np.arange(start=-270, stop=90, step=1)
+        bounds = (-90, 269)
+        offset = calculate_offset(a, bounds)
+
+        # a_where = dataset_roll(a, offset, bounds)
+        # assert np.array_equal(a_where, np.arange(start=-90, stop=270, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-90, stop=270, step=1))
+
+    # offset = -270 - FAILS
+    def test_to_0_359(self):
+        a = np.arange(start=-270, stop=90, step=1)
+        bounds = (0, 359)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=0, stop=360, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=0, stop=360, step=1))
+
+
+class TestLonRoll_minus_360_0:
+
+    # offset = 0
+    def test_to_minus_359_0(self):
+        a = np.arange(start=-359, stop=1, step=1)
+        bounds = (-359, 0)
+        offset = calculate_offset(a, bounds)
+
+        a_where = dataset_roll(a, offset, bounds)
+        assert np.array_equal(a_where, np.arange(start=-359, stop=1, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-359, stop=1, step=1))
+
+    # offset = -89
+    def test_to_minus_270_to_89(self):
+        a = np.arange(start=-359, stop=1, step=1)
+        bounds = (-270, 89)
+        offset = calculate_offset(a, bounds)
+
+        # a_where = dataset_roll(a, offset, bounds)
+        # assert np.array_equal(a_where, np.arange(start=-270, stop=90, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-270, stop=90, step=1))
+
+    # offset = -179
+    def test_to_minus_180_179(self):
+        a = np.arange(start=-359, stop=1, step=1)
+        bounds = (-180, 179)
+        offset = calculate_offset(a, bounds)
+
+        # a_where = dataset_roll(a, offset, bounds)
+        # assert np.array_equal(a_where, np.arange(start=-180, stop=180, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-180, stop=180, step=1))
+
+    # offset = -269
+    def test_to_minus_90_269(self):
+        a = np.arange(start=-359, stop=1, step=1)
+        bounds = (-90, 269)
+        offset = calculate_offset(a, bounds)
+
+        # a_where = dataset_roll(a, offset, bounds)
+        # assert np.array_equal(a_where, np.arange(start=-90, stop=270, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=-90, stop=270, step=1))
+
+    # offset = -359
+    def test_to_0_359(self):
+        a = np.arange(start=-359, stop=1, step=1)
+        bounds = (0, 359)
+        offset = calculate_offset(a, bounds)
+
+        # a_where = dataset_roll(a, offset, bounds)
+        # assert np.array_equal(a_where, np.arange(start=0, stop=360, step=1))
+
+        a_offset = dataset_roll_using_offset(a, offset)
+        assert np.array_equal(a_offset, np.arange(start=0, stop=360, step=1))

--- a/tests/test_roll.py
+++ b/tests/test_roll.py
@@ -159,7 +159,6 @@ def test_xarray_roll_lon(tmpdir):
         )
 
 
-# seems to take a while..
 @pytest.mark.skipif(os.path.isdir("/badc") is False, reason="data not available")
 @pytest.mark.skip(reason="rolling now done within subset")
 def test_convert_lon_coords(tmpdir):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #127 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion minor` has been called on this branch
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Bug fix - fixes the longitude values when a dataset is rolled and also makes sure that the rolled dataset has attributes for longitude.

I tried two methods (in `test_dataset_roll.py`) and the method that changes values using the offset as the index works in all tests. I didn't manage to get the other method to work for all cases where the offset is negative. 