### PR TITLE
Better support for disjoint shapes in subset_shape

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Version History
 ===============
 
+v0.6.2 (unreleased)
+-------------------
+
+Bug Fixes
+^^^^^^^^^
+* Better support for disjoint shapes in ``subset_shape``.
+
 v0.6.1 (2021-02-23)
 -------------------
 Bug Fixes

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -592,7 +592,9 @@ def subset_shape(
     """Subset a DataArray or Dataset spatially (and temporally) using a vector shape and date selection.
 
     Return a subset of a DataArray or Dataset for grid points falling within the area of a Polygon and/or
-    MultiPolygon shape, or grid points along the path of a LineString and/or MultiLineString.
+    MultiPolygon shape, or grid points along the path of a LineString and/or MultiLineString. If the shape
+    consists of several disjoint polygons, the output is cut to the smallest bbox including all
+    polygons.
 
     Parameters
     ----------

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -739,9 +739,8 @@ def subset_shape(
 
     mask_2d = create_mask(
         x_dim=ds_copy.lon, y_dim=ds_copy.lat, poly=poly, wrap_lons=wrap_lons
-    ).clip(
-        1, 1
-    )  # 1 on the shapes, NaN elsewhere
+    ).clip(1, 1)
+    # 1 on the shapes, NaN elsewhere. We simply want to remove the 0s from the zeroth shape, for our outer mask trick below.
 
     if np.all(mask_2d.isnull()):
         raise ValueError(
@@ -755,6 +754,9 @@ def subset_shape(
     # we dont want to drop the inner NaN regions, it may cause problems downstream.
     inner_mask = xarray.full_like(mask_2d, True, dtype=bool)
     for dim in sp_dims:
+        # For each dimension, propagate shape indexes in either directions
+        # Then sum on the other dimension. You get a step function going from 0 to X.
+        # The non-zero part that left and right have in common is the "inner" zone.
         left = mask_2d.bfill(dim).sum(sp_dims - {dim})
         right = mask_2d.ffill(dim).sum(sp_dims - {dim})
         # True in the inner zone, False in the outer
@@ -769,6 +771,9 @@ def subset_shape(
             # 1st mask values outside shape, then drop values outside inner_mask
             ds_copy[v] = ds_copy[v].where(mask_2d.notnull())
 
+    # Remove grid points outside the inner mask
+    # Then extract the coords.
+    # Using a where(inner_mask) on ds_copy triggers warnings with dask, sel seems safer.
     mask_2d = mask_2d.where(inner_mask, drop=True)
     for dim in sp_dims:
         ds_copy = ds_copy.sel({dim: mask_2d[dim]})

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -948,10 +948,12 @@ class TestSubsetLevel:
 
         with pytest.warns(None) as record:
             subset.subset_level(da, first_level=81200, last_level=54100.6)
-        assert [str(q.message) for q in record] == [
+
+        msgs = {
             '"first_level" has been nudged to nearest valid level in xarray object.',
             '"last_level" has been nudged to nearest valid level in xarray object.',
-        ]
+        }
+        assert msgs.issubset({str(q.message) for q in record})
 
     def test_level_first_only(self):
         da = xr.open_dataset(self.nc_plev).o3

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -738,7 +738,7 @@ class TestSubsetShape:
 
         # Average temperature at surface for region in January (time=0)
         np.testing.assert_array_almost_equal(
-            float(np.mean(sub.tasmax.isel(time=0))), 269.2540588378906
+            float(np.mean(sub.tasmax.isel(time=0))), 269.254059
         )
         # Check that no warnings are raised for meridian crossing
         assert (
@@ -825,6 +825,7 @@ class TestSubsetShape:
         regions.set_index("id")
         ds_sub = subset.subset_shape(ds, shape=regions)
         assert ds_sub.notnull().sum() == 58 + 250 + 22
+        assert ds_sub.tas.shape == (12, 14, 128)
 
     def test_vectorize_touches_polygons(self):
         """Check that points touching the polygon are included in subset."""

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -678,14 +678,14 @@ class TestSubsetShape:
 
         # Average temperature at surface for region in January (time=0)
         np.testing.assert_array_almost_equal(
-            float(np.mean(sub.tas.isel(time=0))), 285.064453
+            float(np.mean(sub.tas.isel(time=0))), 285.064, 3
         )
         self.compare_vals(ds, sub, "tas")
 
         poly = gpd.read_file(self.meridian_multi_geojson)
         subtas = subset.subset_shape(ds.tas, poly)
         np.testing.assert_array_almost_equal(
-            float(np.mean(subtas.isel(time=0))), 281.091553
+            float(np.mean(subtas.isel(time=0))), 281.092, 3
         )
 
         assert sub.crs.prime_meridian_name == "Greenwich"
@@ -710,7 +710,7 @@ class TestSubsetShape:
 
         # Average temperature at surface for region in January (time=0)
         np.testing.assert_array_almost_equal(
-            float(np.mean(sub.tas.isel(time=0))), 276.732483
+            float(np.mean(sub.tas.isel(time=0))), 276.732, 3
         )
         # Check that no warnings are raised for meridian crossing
         assert (
@@ -738,7 +738,7 @@ class TestSubsetShape:
 
         # Average temperature at surface for region in January (time=0)
         np.testing.assert_array_almost_equal(
-            float(np.mean(sub.tasmax.isel(time=0))), 269.254059
+            float(np.mean(sub.tasmax.isel(time=0))), 269.254, 3
         )
         # Check that no warnings are raised for meridian crossing
         assert (
@@ -949,12 +949,8 @@ class TestSubsetLevel:
         with pytest.warns(None) as record:
             subset.subset_level(da, first_level=81200, last_level=54100.6)
         assert [str(q.message) for q in record] == [
-            "Variables {'lat_bnds'} not found in object but are referred to in the CF attributes.",
-            "Variables {'lon_bnds'} not found in object but are referred to in the CF attributes.",
             '"first_level" has been nudged to nearest valid level in xarray object.',
             '"last_level" has been nudged to nearest valid level in xarray object.',
-            "Variables {'lat_bnds'} not found in object but are referred to in the CF attributes.",
-            "Variables {'lon_bnds'} not found in object but are referred to in the CF attributes.",
         ]
 
     def test_level_first_only(self):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #137
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->

Before dropping values outside the mask in `subset_shape`, it computes an "inner mask", True inside a bbox delimited by all the shapes. It only drops values outside that inner part.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
Yes, outputs of  `subset_shape` will be different when used with disjoint shapes.