### PR TITLE
Raise exception in subset_bbox when no data in output

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,8 @@ Version History
 
 v0.6.3 (Unreleased)
 -------------------
-Bug Fixes
-^^^^^^^^^
+Breaking Change
+^^^^^^^^^^^^^^^
 * Raise an exception in ``core.subset.subset_bbox`` when there are no data points in the result.
 
 v0.6.2 (2021-03-22)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Version History
 ===============
 
+v0.6.3 (Unreleased)
+-------------------
+Bug Fixes
+^^^^^^^^^
+* Raise an exception in ``core.subset.subset_bbox`` when there are no data points in the result.
+
 v0.6.2 (2021-03-22)
 -------------------
 

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -642,11 +642,11 @@ def subset_shape(
     # Only case not implemented is when lon_bnds cross the 0 deg meridian but dataset grid has all positive lons
     try:
         ds_copy = subset_bbox(ds_copy, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
-    except ValueError:
+    except ValueError as e:
         raise ValueError(
             "No grid cell centroids found within provided polygon bounding box. "
             'Try using the "buffer" option to create an expanded area.'
-        )
+        ) from e
     except NotImplementedError:
         pass
 

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -21,8 +21,6 @@ from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.ops import cascaded_union, split
 from xarray.core.utils import get_temp_dimname
 
-from clisops.utils.output_utils import get_da
-
 __all__ = [
     "create_mask",
     "distance",

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -21,6 +21,8 @@ from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.ops import cascaded_union, split
 from xarray.core.utils import get_temp_dimname
 
+from clisops.utils.output_utils import get_da
+
 __all__ = [
     "create_mask",
     "distance",
@@ -640,17 +642,16 @@ def subset_shape(
     # Only case not implemented is when lon_bnds cross the 0 deg meridian but dataset grid has all positive lons
     try:
         ds_copy = subset_bbox(ds_copy, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
+    except ValueError:
+        raise ValueError(
+            "No grid cell centroids found within provided polygon bounding box. "
+            'Try using the "buffer" option to create an expanded area.'
+        )
     except NotImplementedError:
         pass
 
     lon = get_lon(ds_copy)
     lat = get_lat(ds_copy)
-
-    if lon.size == 0 or lat.size == 0:
-        raise ValueError(
-            "No grid cell centroids found within provided polygon bounding box. "
-            'Try using the "buffer" option to create an expanded area.'
-        )
 
     if start_date or end_date:
         ds_copy = subset_time(ds_copy, start_date=start_date, end_date=end_date)
@@ -889,6 +890,11 @@ def subset_bbox(
 
     if first_level or last_level:
         da = subset_level(da, first_level=first_level, last_level=last_level)
+
+    if da[lat].size == 0 or da[lon].size == 0:
+        raise ValueError(
+            "There were no valid data points found in the requested subset."
+        )
 
     return da
 

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -14,7 +14,7 @@ from clisops.ops.base_operation import Operation
 from clisops.utils.common import expand_wildcards
 from clisops.utils.dataset_utils import check_lon_alignment
 from clisops.utils.file_namers import get_file_namer
-from clisops.utils.output_utils import get_output, get_time_slices
+from clisops.utils.output_utils import get_da, get_output, get_time_slices
 
 __all__ = [
     "subset",
@@ -89,6 +89,9 @@ class Subset(Operation):
             if any(kwargs.values()):
                 LOGGER.debug(f"subset_level with parameters: {kwargs}")
                 result = subset_level(result, **kwargs)
+
+        if get_da(result).nbytes == 0:
+            raise Exception("No data found in requested subset.")
 
         return result
 

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -14,7 +14,7 @@ from clisops.ops.base_operation import Operation
 from clisops.utils.common import expand_wildcards
 from clisops.utils.dataset_utils import check_lon_alignment
 from clisops.utils.file_namers import get_file_namer
-from clisops.utils.output_utils import get_da, get_output, get_time_slices
+from clisops.utils.output_utils import get_output, get_time_slices
 
 __all__ = [
     "subset",
@@ -89,9 +89,6 @@ class Subset(Operation):
             if any(kwargs.values()):
                 LOGGER.debug(f"subset_level with parameters: {kwargs}")
                 result = subset_level(result, **kwargs)
-
-        if get_da(result).nbytes == 0:
-            raise Exception("No data found in requested subset.")
 
         return result
 

--- a/clisops/utils/output_utils.py
+++ b/clisops/utils/output_utils.py
@@ -74,7 +74,7 @@ def filter_times_within(times, start=None, end=None):
 
 
 def get_da(ds):
-    """ Returns xr.DataArray when format of ds may be either."""
+    """ Returns xr.DataArray when format of ds may be either xr.Dataset or xr.DataArray."""
     if isinstance(ds, xr.DataArray):
         da = ds
     else:

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -886,7 +886,6 @@ class TestSubset:
 
 def test_no_lon_in_range():
 
-    # area=(8.37, 39.12, 8.56, 39.26)
     with pytest.raises(Exception) as exc:
         subset(
             ds=CMIP6_RLDS_ONE_TIME_STEP,
@@ -895,7 +894,10 @@ def test_no_lon_in_range():
             output_type="xarray",
         )
 
-    assert str(exc.value) == "No data found in requested subset."
+    assert (
+        str(exc.value)
+        == "There were no valid data points found in the requested subset."
+    )
 
 
 def test_no_lat_in_range():
@@ -908,7 +910,10 @@ def test_no_lat_in_range():
             output_type="xarray",
         )
 
-    assert str(exc.value) == "No data found in requested subset."
+    assert (
+        str(exc.value)
+        == "There were no valid data points found in the requested subset."
+    )
 
 
 def test_no_lat_lon_in_range():
@@ -921,4 +926,7 @@ def test_no_lat_lon_in_range():
             output_type="xarray",
         )
 
-    assert str(exc.value) == "No data found in requested subset."
+    assert (
+        str(exc.value)
+        == "There were no valid data points found in the requested subset."
+    )

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -19,6 +19,7 @@ from .._common import (
     CMIP5_ZOSTOGA,
     CMIP6_MRSOFC,
     CMIP6_RLDS,
+    CMIP6_RLDS_ONE_TIME_STEP,
     CMIP6_TA,
     CMIP6_TOS,
 )
@@ -592,7 +593,7 @@ def test_time_invariant_subset_standard_name(load_esgf_test_data, tmpdir):
 
     result = subset(
         ds=CMIP6_MRSOFC,
-        area=(5.0, 10.0, 20.0, 65.0),
+        area=(5.0, 10.0, 360.0, 90.0),
         output_dir=tmpdir,
         output_type="nc",
         file_namer="standard",
@@ -621,7 +622,7 @@ def test_time_invariant_subset_simple_name(load_esgf_test_data, tmpdir):
 
     result = subset(
         ds=CMIP6_MRSOFC,
-        area=(5.0, 10.0, 20.0, 65.0),
+        area=(5.0, 10.0, 360.0, 90.0),
         output_dir=tmpdir,
         output_type="nc",
         file_namer="simple",
@@ -636,7 +637,7 @@ def test_time_invariant_subset_with_time(load_esgf_test_data):
         subset(
             ds=CMIP6_MRSOFC,
             time=("2005-01-01T00:00:00", "2020-12-30T00:00:00"),
-            area=(5.0, 10.0, 20.0, 65.0),
+            area=(5.0, 10.0, 360.0, 90.0),
             output_type="xarray",
         )
     assert str(exc.value) == "'Dataset' object has no attribute 'time'"
@@ -881,3 +882,43 @@ class TestSubset:
                 ds=cmip5_tas_file,
                 area=("zero", 10, 50, 60),
             )
+
+
+def test_no_lon_in_range():
+
+    # area=(8.37, 39.12, 8.56, 39.26)
+    with pytest.raises(Exception) as exc:
+        subset(
+            ds=CMIP6_RLDS_ONE_TIME_STEP,
+            area=(8.37, -90, 8.56, 90),
+            time=("2006-01-01T00:00:00", "2099-12-30T00:00:00"),
+            output_type="xarray",
+        )
+
+    assert str(exc.value) == "No data found in requested subset."
+
+
+def test_no_lat_in_range():
+
+    with pytest.raises(Exception) as exc:
+        subset(
+            ds=CMIP6_RLDS_ONE_TIME_STEP,
+            area=(0, 39.12, 360, 39.26),
+            time=("2006-01-01T00:00:00", "2099-12-30T00:00:00"),
+            output_type="xarray",
+        )
+
+    assert str(exc.value) == "No data found in requested subset."
+
+
+def test_no_lat_lon_in_range():
+
+    with pytest.raises(Exception) as exc:
+        subset(
+            ds=CMIP6_RLDS_ONE_TIME_STEP,
+            area=(8.37, 39.12, 8.56, 39.26),
+            time=("2006-01-01T00:00:00", "2099-12-30T00:00:00"),
+            output_type="xarray",
+        )
+
+    assert str(exc.value) == "No data found in requested subset."


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue https://github.com/roocs/daops/issues/61
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Raises an exception in `subset_bbox` if there are no data points in the result. In these cases, our subset requests were failing further down the line and the exception raised wasn't very informative.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
`subset_bbox` will now raise an exception in cases where it would not have previously 

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
