### PR TITLE
improve error message when rolling could not be completed

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,10 @@ Breaking Change
 ^^^^^^^^^^^^^^^
 * Raise an exception in ``core.subset.subset_bbox`` when there are no data points in the result.
 
+Other Changes
+^^^^^^^^^^^^^
+* Error message improved to include longitude bounds of the dataset when the bounds requested in ``ops.subset.subset`` are not within range and rolling could not be completed.
+
 v0.6.2 (2021-03-22)
 -------------------
 

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -67,7 +67,7 @@ class Subset(Operation):
                 lon_min, lon_max = lon.values.min(), lon.values.max()
                 raise Exception(
                     f"The input longitude bounds {self.params.get('lon_bnds')} are not within the longitude bounds "
-                    f"of this dataset and rolling could not be completed successfully. "
+                    f"of this dataset and the data could not be converted to this longitude frame successfully. "
                     f"Please re-run your request with longitudes within the bounds of the dataset: ({lon_min:.2f}, {lon_max:.2f})"
                 )
         else:

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -10,6 +10,7 @@ from roocs_utils.xarray_utils.xarray_utils import open_xr_dataset
 
 from clisops import logging
 from clisops.core import subset_bbox, subset_level, subset_time
+from clisops.core.subset import get_lon
 from clisops.ops.base_operation import Operation
 from clisops.utils.common import expand_wildcards
 from clisops.utils.dataset_utils import check_lon_alignment
@@ -62,10 +63,12 @@ class Subset(Operation):
             try:
                 result = subset_bbox(ds, **self.params)
             except NotImplementedError:
+                lon = get_lon(ds)
+                lon_min, lon_max = lon.values.min(), lon.values.max()
                 raise Exception(
                     f"The input longitude bounds {self.params.get('lon_bnds')} are not within the longitude bounds "
                     f"of this dataset and rolling could not be completed successfully. "
-                    f"Please re-run your request with longitudes within the bounds of the dataset."
+                    f"Please re-run your request with longitudes within the bounds of the dataset: ({lon_min:.2f}, {lon_max:.2f})"
                 )
         else:
             kwargs = {}

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -66,7 +66,7 @@ class Subset(Operation):
                 lon = get_lon(ds)
                 lon_min, lon_max = lon.values.min(), lon.values.max()
                 raise Exception(
-                    f"The input longitude bounds {self.params.get('lon_bnds')} are not within the longitude bounds "
+                    f"The requested longitude subset {self.params.get('lon_bnds')} is not within the longitude bounds "
                     f"of this dataset and the data could not be converted to this longitude frame successfully. "
                     f"Please re-run your request with longitudes within the bounds of the dataset: ({lon_min:.2f}, {lon_max:.2f})"
                 )

--- a/clisops/utils/dataset_utils.py
+++ b/clisops/utils/dataset_utils.py
@@ -60,9 +60,9 @@ def check_lon_alignment(ds, lon_bnds):
         # check if lon is a dimension
         if lon.name not in ds.dims:
             raise Exception(
-                f"The longitude of this dataset runs from {lon_min:.2f} to {lon_max:.2f}, "
-                f"and rolling could not be completed successfully. "
-                f"Please re-run your request with longitudes between these bounds."
+                f"The input longitude bounds {lon_bnds} are not within the longitude bounds "
+                f"of this dataset and rolling could not be completed successfully. "
+                f"Please re-run your request with longitudes within the bounds of the dataset: ({lon_min:.2f}, {lon_max:.2f})"
             )
         # roll the dataset and reassign the longitude values
         else:

--- a/clisops/utils/dataset_utils.py
+++ b/clisops/utils/dataset_utils.py
@@ -60,7 +60,7 @@ def check_lon_alignment(ds, lon_bnds):
         # check if lon is a dimension
         if lon.name not in ds.dims:
             raise Exception(
-                f"The input longitude bounds {lon_bnds} are not within the longitude bounds "
+                f"The requested longitude subset {lon_bnds} is not within the longitude bounds "
                 f"of this dataset and the data could not be converted to this longitude frame successfully. "
                 f"Please re-run your request with longitudes within the bounds of the dataset: ({lon_min:.2f}, {lon_max:.2f})"
             )

--- a/clisops/utils/dataset_utils.py
+++ b/clisops/utils/dataset_utils.py
@@ -61,7 +61,7 @@ def check_lon_alignment(ds, lon_bnds):
         if lon.name not in ds.dims:
             raise Exception(
                 f"The input longitude bounds {lon_bnds} are not within the longitude bounds "
-                f"of this dataset and rolling could not be completed successfully. "
+                f"of this dataset and the data could not be converted to this longitude frame successfully. "
                 f"Please re-run your request with longitudes within the bounds of the dataset: ({lon_min:.2f}, {lon_max:.2f})"
             )
         # roll the dataset and reassign the longitude values

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -820,7 +820,7 @@ def test_check_lon_alignment_curvilinear_grid():
         )
     assert (
         str(exc.value)
-        == "The input longitude bounds (-50.0, 100.0) are not within the longitude bounds "
+        == "The requested longitude subset (-50.0, 100.0) is not within the longitude bounds "
         "of this dataset and the data could not be converted to this longitude frame successfully. "
         "Please re-run your request with longitudes within the bounds of the dataset: (0.00, 359.99)"
     )
@@ -837,7 +837,7 @@ def test_could_not_roll():
         )
     assert (
         str(exc.value)
-        == "The input longitude bounds (160.0, -100.0) are not within the longitude "
+        == "The requested longitude subset (160.0, -100.0) is not within the longitude "
         "bounds of this dataset and the data could not be converted to this longitude frame successfully. "
         "Please re-run your request with longitudes within the bounds of the dataset: (0.00, 357.50)"
     )

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -805,7 +805,7 @@ def test_roll_positive_mini_data():
 
 
 @pytest.mark.skipif(Path("/badc").is_dir() is False, reason="data not available")
-def test_check_lon_alignment_irregular_grid():
+def test_check_lon_alignment_curvilinear_grid():
     ds = _load_ds(
         "/badc/cmip6/data/CMIP6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/Ofx/sftof/gn/v20191108/*.nc"
     )
@@ -819,9 +819,27 @@ def test_check_lon_alignment_irregular_grid():
             output_type="xarray",
         )
     assert (
-        str(exc.value) == "The longitude of this dataset runs from 0.00 to 359.99, "
-        "and rolling could not be completed successfully. "
-        "Please re-run your request with longitudes between these bounds."
+        str(exc.value)
+        == "The input longitude bounds (-50.0, 100.0) are not within the longitude bounds "
+        "of this dataset and rolling could not be completed successfully. "
+        "Please re-run your request with longitudes within the bounds of the dataset: (0.00, 359.99)"
+    )
+
+
+def test_could_not_roll():
+    area = (160, 45, -100, 90)
+
+    with pytest.raises(Exception) as exc:
+        subset(
+            ds=CMIP6_RLDS_ONE_TIME_STEP,
+            area=area,
+            output_type="xarray",
+        )
+    assert (
+        str(exc.value)
+        == "The input longitude bounds (160.0, -100.0) are not within the longitude "
+        "bounds of this dataset and rolling could not be completed successfully. "
+        "Please re-run your request with longitudes within the bounds of the dataset: (0.00, 357.50)"
     )
 
 

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -821,7 +821,7 @@ def test_check_lon_alignment_curvilinear_grid():
     assert (
         str(exc.value)
         == "The input longitude bounds (-50.0, 100.0) are not within the longitude bounds "
-        "of this dataset and rolling could not be completed successfully. "
+        "of this dataset and the data could not be converted to this longitude frame successfully. "
         "Please re-run your request with longitudes within the bounds of the dataset: (0.00, 359.99)"
     )
 
@@ -838,7 +838,7 @@ def test_could_not_roll():
     assert (
         str(exc.value)
         == "The input longitude bounds (160.0, -100.0) are not within the longitude "
-        "bounds of this dataset and rolling could not be completed successfully. "
+        "bounds of this dataset and the data could not be converted to this longitude frame successfully. "
         "Please re-run your request with longitudes within the bounds of the dataset: (0.00, 357.50)"
     )
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Error message improved to include longitude bounds of the dataset when the bounds requested in a subset (`ops.subset`) are not within range and rolling could not be completed.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->


* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
