### PR TITLE
Issue/64/apply along axis error

### DIFF
--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -850,10 +850,18 @@ def subset_bbox(
         args = dict()
 
         for i, d in enumerate(da[lat].dims):
-            coords = da[d][ind[i]]
-            bnds = _check_desc_coords(
-                coord=da[d], bounds=[coords.min().values, coords.max().values], dim=d
-            )
+            try:
+                coords = da[d][ind[i]]
+                bnds = _check_desc_coords(
+                    coord=da[d],
+                    bounds=[coords.min().values, coords.max().values],
+                    dim=d,
+                )
+            except ValueError:
+                raise ValueError(
+                    "There were no valid data points found in the requested subset. Please expand "
+                    "the area covered by the bounding box."
+                )
             args[d] = slice(*bnds)
         # If the dims of lat and lon do not have coords, sel defaults to isel,
         # and then the last element is not returned.

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -848,6 +848,7 @@ def subset_bbox(
         # Crop original array using slice, which is faster than `where`.
         ind = np.where(lon_cond & lat_cond)
         args = dict()
+
         for i, d in enumerate(da[lat].dims):
             coords = da[d][ind[i]]
             bnds = _check_desc_coords(
@@ -857,6 +858,12 @@ def subset_bbox(
         # If the dims of lat and lon do not have coords, sel defaults to isel,
         # and then the last element is not returned.
         da = da.sel(**args)
+
+        if da[lat].size == 0 or da[lon].size == 0:
+            raise ValueError(
+                "There were no valid data points found in the requested subset. Please expand "
+                "the area covered by the bounding box."
+            )
 
         # Recompute condition on cropped coordinates
         if lat_bnds is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ["setup.py"]
-# addopts = --verbose tests
+addopts = --verbose tests
 filterwarnings = 
 	ignore::UserWarning
 markers = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ["setup.py"]
-addopts = --verbose tests
+# addopts = --verbose tests
 filterwarnings = 
 	ignore::UserWarning
 markers = 

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -128,3 +128,9 @@ CMIP6_TOS = Path(
     MINI_ESGF_CACHE_DIR,
     "master/test_data/badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/Omon/tos/gn/v20190710/tos_Omon_MPI-ESM1-2-LR_historical_r1i1p1f1_gn_185001-186912.nc",
 ).as_posix()
+
+
+CMIP6_TOS_ONE_TIME_STEP = Path(
+    MINI_ESGF_CACHE_DIR,
+    "master/test_data/badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/Omon/tos/gn/v20190710/tos_Omon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_185001.nc",
+).as_posix()

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -998,7 +998,7 @@ def test_curvilinear_ds_no_data_in_bbox():
         )
     assert (
         str(exc.value)
-        == "zero-size array to reduction operation minimum which has no identity"
+        == "There were no valid data points found in the requested subset. Please expand the area covered by the bounding box."
     )
 
 

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -22,6 +22,7 @@ from .._common import (
     CMIP6_RLDS_ONE_TIME_STEP,
     CMIP6_TA,
     CMIP6_TOS,
+    CMIP6_TOS_ONE_TIME_STEP,
 )
 
 
@@ -947,4 +948,65 @@ def test_no_lat_lon_in_range():
     assert (
         str(exc.value)
         == "There were no valid data points found in the requested subset."
+    )
+
+
+@pytest.mark.skipif(Path("/badc").is_dir() is False, reason="data not available")
+def test_curvilinear_ds_no_data_in_bbox_real_data():
+    ds = _load_ds(
+        "/badc/cmip6/data/CMIP6/ScenarioMIP/CNRM-CERFACS/CNRM-CM6-1/ssp245/r1i1p1f2/Omon/tos/gn/v20190219/tos_Omon_CNRM-CM6-1_ssp245_r1i1p1f2_gn_201501-210012.nc"
+    )
+    with pytest.raises(ValueError) as exc:
+        subset(
+            ds=ds,
+            area="1,40,2,4",
+            time="2021-01-01/2050-12-31",
+            output_type="xarray",
+        )
+    assert (
+        str(exc.value)
+        == "There were no valid data points found in the requested subset. Please expand the area covered by the bounding box."
+    )
+
+
+@pytest.mark.skipif(Path("/badc").is_dir() is False, reason="data not available")
+def test_curvilinear_ds_no_data_in_bbox_real_data_swap_lat():
+    ds = _load_ds(
+        "/badc/cmip6/data/CMIP6/ScenarioMIP/CNRM-CERFACS/CNRM-CM6-1/ssp245/r1i1p1f2/Omon/tos/gn/v20190219/tos_Omon_CNRM-CM6-1_ssp245_r1i1p1f2_gn_201501-210012.nc"
+    )
+    with pytest.raises(ValueError) as exc:
+        subset(
+            ds=ds,
+            area="1,4,2,40",
+            time="2021-01-01/2050-12-31",
+            output_type="xarray",
+        )
+    assert (
+        str(exc.value)
+        == "There were no valid data points found in the requested subset. Please expand the area covered by the bounding box."
+    )
+
+
+def test_curvilinear_ds_no_data_in_bbox():
+
+    with pytest.raises(ValueError) as exc:
+        subset(
+            ds=CMIP6_TOS_ONE_TIME_STEP,
+            area="1,40,1.00001,4",
+            time="2021-01-01/2050-12-31",
+            output_type="xarray",
+        )
+    assert (
+        str(exc.value)
+        == "zero-size array to reduction operation minimum which has no identity"
+    )
+
+
+def test_curvilinear_increase_lon_of_bbox():
+
+    subset(
+        ds=CMIP6_TOS_ONE_TIME_STEP,
+        area="1,40,4,4",
+        time="2021-01-01/2050-12-31",
+        output_type="xarray",
     )

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -992,7 +992,7 @@ def test_curvilinear_ds_no_data_in_bbox():
     with pytest.raises(ValueError) as exc:
         subset(
             ds=CMIP6_TOS_ONE_TIME_STEP,
-            area="1,40,1.00001,4",
+            area="1,5,1.2,4",
             time="2021-01-01/2050-12-31",
             output_type="xarray",
         )


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue https://github.com/roocs/daops/issues/64
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Provides a more useful error message when the size of a dimension is 0 after subsetting in `subset_bbox` for the curvilinear case.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->


* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
@agstephens @cehbrecht 
I have added a test for the other error mentioned in the issue https://github.com/roocs/daops/issues/64. This is the case where a small bounding box results in the error "zero-size array to reduction operation minimum which has no identity". I'm not sure of the best way to handle this error as well, should we also raise the same error message in this case?