### PR TITLE
Do not disable other loggers.

### DIFF
--- a/clisops/__init__.py
+++ b/clisops/__init__.py
@@ -11,7 +11,8 @@ import clisops
 from .__version__ import __author__, __email__, __version__
 
 logging.config.fileConfig(
-    os.path.join(os.path.dirname(__file__), "etc", "logging.conf")
+    os.path.join(os.path.dirname(__file__), "etc", "logging.conf"),
+    disable_existing_loggers=False,
 )
 CONFIG = get_config(clisops)
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
The built-in logging config parser disables all other existing loggers by default. Our pyWPS library, `finch` relies on the PYWPS logger to communicate bugs and stuff, but since we integrate clisops nothing was getting printed to the log file, because of this.
I do not know why they would made this option the default, it seems counter productive to me and I can testify that it is quite a complex behavior to debug...

I did find this section in the official python docs : https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
Seems like the use made here (a library configuring a complete logger) is not the recommended way. I didn't know that and, with this fix, it doesn't bother me at all, but this is a discussion we might want to have.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
This link might also be of interest: https://docs.python-guide.org/writing/logging/#logging-in-a-library