### PR TITLE
raise exception when dims is None in average_over_dims

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ Version History
 v0.6.4 (unreleased)
 -------------------
 
+Breaking Changes
+^^^^^^^^^^^^^^^^
+* Exception raised in ``core.average.average_over_dims`` when dims is None.
+
 New Features
 ^^^^^^^^^^^^
 * ``ops.subset.subset`` now ensures all latitude and longitude bounds are in ascending order before passing to ``core.subset.subset_bbox``

--- a/clisops/core/average.py
+++ b/clisops/core/average.py
@@ -130,7 +130,9 @@ def average_over_dims(
     """
 
     if not dims:
-        return ds
+        raise InvalidParameterValue(
+            "At least one dimension for averaging must be provided"
+        )
 
     if not set(dims).issubset(set(known_coord_types)):
         raise InvalidParameterValue(

--- a/tests/core/test_average.py
+++ b/tests/core/test_average.py
@@ -1,8 +1,8 @@
 import os
-import pytest
 
 import geopandas as gpd
 import numpy as np
+import pytest
 import xarray as xr
 from roocs_utils.exceptions import InvalidParameterValue
 
@@ -87,9 +87,9 @@ class TestAverageOverDims:
     def test_average_no_dims(self):
         ds = xr.open_dataset(self.nc_file)
 
-        avg_ds = average.average_over_dims(ds)
-
-        assert avg_ds == ds
+        with pytest.raises(InvalidParameterValue) as exc:
+            average.average_over_dims(ds)
+        assert str(exc.value) == "At least one dimension for averaging must be provided"
 
     def test_average_one_dim(self):
         ds = xr.open_dataset(self.nc_file)

--- a/tests/ops/test_average.py
+++ b/tests/ops/test_average.py
@@ -21,21 +21,6 @@ def _load_ds(fpath):
     return xr.open_mfdataset(fpath)
 
 
-def test_average_basic(tmpdir):
-    result = average_over_dims(
-        CMIP5_TAS,
-        dims=None,
-        ignore_undetected_dims=False,
-        output_dir=tmpdir,
-        output_type="netcdf",
-        file_namer="standard",
-    )
-
-    _check_output_nc(
-        result, fname="tas_mon_HadGEM2-ES_rcp85_r1i1p1_20051216-22991216.nc"
-    )
-
-
 def test_average_basic_data_array(cmip5_tas_file):
     ds = xr.open_dataset(cmip5_tas_file)
     result = average_over_dims(
@@ -160,6 +145,17 @@ def test_average_multiple_dims_xarray():
 
     assert "time" not in result[0]
     assert "lon" not in result[0]
+
+
+def test_average_no_dims(tmpdir):
+    with pytest.raises(InvalidParameterValue) as exc:
+        average_over_dims(
+            CMIP5_TAS,
+            dims=None,
+            ignore_undetected_dims=False,
+            output_type="xarray",
+        )
+    assert str(exc.value) == "At least one dimension for averaging must be provided"
 
 
 def test_unknown_dim():


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue https://github.com/roocs/rook/issues/135
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
An exception is now raised when dims is None. If dims is an empty string it will be converted to None by `dims = DimensionParameter(params.get("dims", None)).tuple`

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
Yes - raises an exception where it previously didn't

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
I will update the tests on `daops` and `rook` as well 
