### PR TITLE
Make spatial averaging fail if no overlap in grid and shape and update black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,13 @@ repos:
     -   id: debug-statements
         language_version: python3
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.4b2
     hooks:
     -   id: black
         language_version: python3
         args: ["--target-version", "py36"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.1
     hooks:
     -   id: flake8
         language_version: python3
@@ -33,7 +33,7 @@ repos:
 #    -   id: autopep8
 #        args: ['--global-config=setup.cfg','--in-place']
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.7.0
+    rev: 5.8.0
     hooks:
     -   id: isort
         language_version: python3
@@ -44,7 +44,7 @@ repos:
 #    -   id: pydocstyle
 #        args: ["--conventions=numpy"]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.9.0
+    rev: v2.14.0
     hooks:
     -   id: pyupgrade
         language_version: python3
@@ -53,7 +53,7 @@ repos:
     -   id: check-hooks-apply
     -   id: check-useless-excludes
 -   repo: https://github.com/kynan/nbstripout
-    rev: 0.3.9
+    rev: 0.4.0
     hooks:
     -   id: nbstripout
         language_version: python3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ v0.6.4 (unreleased)
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 * Exception raised in ``core.average.average_over_dims`` when dims is None.
+* Exception raised in ``core.average.average_over_shape`` when grid and polygon have no overlapping values.
 
 New Features
 ^^^^^^^^^^^^

--- a/clisops/core/average.py
+++ b/clisops/core/average.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Tuple, Union
 
 import geopandas as gpd
-import numpy as np
 import xarray as xr
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.xarray_utils.xarray_utils import get_coord_type, known_coord_types

--- a/clisops/core/average.py
+++ b/clisops/core/average.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Tuple, Union
 
 import geopandas as gpd
+import numpy as np
 import xarray as xr
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.xarray_utils.xarray_utils import get_coord_type, known_coord_types
@@ -75,6 +76,10 @@ def average_shape(
         poly = poly.to_crs(4326)
 
     savger = SpatialAverager(ds_copy, poly.geometry)
+    if savger.weights.nnz == 0:
+        raise ValueError(
+            "There were no valid data points found in the requested averaging region. Verify objects overlap."
+        )
     ds_out = savger(ds_copy)
 
     # Set geom coords to poly's index

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -710,7 +710,8 @@ def subset_shape(
     mask_2d = create_mask(x_dim=lon, y_dim=lat, poly=poly, wrap_lons=wrap_lons).clip(
         1, 1
     )
-    # 1 on the shapes, NaN elsewhere. We simply want to remove the 0s from the zeroth shape, for our outer mask trick below.
+    # 1 on the shapes, NaN elsewhere.
+    # We simply want to remove the 0s from the zeroth shape, for our outer mask trick below.
 
     if np.all(mask_2d.isnull()):
         raise ValueError(

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(__file__)
 
 class Subset(Operation):
     def _resolve_params(self, **params):
-        """ Generates a dictionary of subset parameters """
+        """Generates a dictionary of subset parameters"""
         time = params.get("time", None)
         area = params.get("area", None)
         level = params.get("level", None)

--- a/clisops/utils/file_namers.py
+++ b/clisops/utils/file_namers.py
@@ -6,14 +6,14 @@ from clisops.utils.output_utils import get_format_extension
 
 
 def get_file_namer(name):
-    """ Returns the correct filenamer from the provided name"""
+    """Returns the correct filenamer from the provided name"""
     namers = {"standard": StandardFileNamer, "simple": SimpleFileNamer}
 
     return namers.get(name, StandardFileNamer)
 
 
 class _BaseFileNamer(object):
-    """ File namer base class"""
+    """File namer base class"""
 
     def __init__(self, replace=None, extra=""):
         self._count = 0
@@ -21,7 +21,7 @@ class _BaseFileNamer(object):
         self._extra = extra
 
     def get_file_name(self, ds, fmt=None):
-        """ Generate numbered file names """
+        """Generate numbered file names"""
         self._count += 1
         extension = get_format_extension(fmt)
         return f"output_{self._count:03d}.{extension}"
@@ -45,7 +45,7 @@ class StandardFileNamer(SimpleFileNamer):
     """
 
     def _get_project(self, ds):
-        """ Gets the project name from the input dataset """
+        """Gets the project name from the input dataset"""
 
         try:
             return get_project_name(ds)
@@ -53,7 +53,7 @@ class StandardFileNamer(SimpleFileNamer):
             return None
 
     def get_file_name(self, ds, fmt="nc"):
-        """ Constructs file name. """
+        """Constructs file name."""
         template = self._get_template(ds)
 
         if not template:
@@ -72,7 +72,7 @@ class StandardFileNamer(SimpleFileNamer):
         return file_name
 
     def _get_template(self, ds):
-        """ Gets template to use for output file name, based on the project of the dataset. """
+        """Gets template to use for output file name, based on the project of the dataset."""
         try:
             return CONFIG[f"project:{self._get_project(ds)}"]["file_name_template"]
         except KeyError:
@@ -100,7 +100,7 @@ class StandardFileNamer(SimpleFileNamer):
                 attrs[key] = value
 
     def _get_time_range(self, da):
-        """ Finds the time range of the data in the output. """
+        """Finds the time range of the data in the output."""
         try:
             times = da.time.values
             return f"_{times.min().strftime('%Y%m%d')}-{times.max().strftime('%Y%m%d')}"

--- a/clisops/utils/output_utils.py
+++ b/clisops/utils/output_utils.py
@@ -28,7 +28,7 @@ SUPPORTED_SPLIT_METHODS = ["time:auto"]
 
 
 def check_format(fmt):
-    """ Checks requested format exists. """
+    """Checks requested format exists."""
     if fmt not in SUPPORTED_FORMATS:
         raise KeyError(
             f'Format not recognised: "{fmt}". Must be one of: {SUPPORTED_FORMATS}.'
@@ -36,19 +36,19 @@ def check_format(fmt):
 
 
 def get_format_writer(fmt):
-    """ Finds the output method for the requested output format. """
+    """Finds the output method for the requested output format."""
     check_format(fmt)
     return SUPPORTED_FORMATS[fmt]["method"]
 
 
 def get_format_extension(fmt):
-    """ Finds the extension for the requested output format. """
+    """Finds the extension for the requested output format."""
     check_format(fmt)
     return SUPPORTED_FORMATS[fmt]["extension"]
 
 
 def _format_time(tm: Union[str, dt], fmt="%Y-%m-%d"):
-    """ Convert to datetime if time is a numpy datetime """
+    """Convert to datetime if time is a numpy datetime"""
     if not hasattr(tm, "strftime"):
         tm = pd.to_datetime(str(tm))
 
@@ -74,7 +74,7 @@ def filter_times_within(times, start=None, end=None):
 
 
 def get_da(ds):
-    """ Returns xr.DataArray when format of ds may be either xr.Dataset or xr.DataArray."""
+    """Returns xr.DataArray when format of ds may be either xr.Dataset or xr.DataArray."""
     if isinstance(ds, xr.DataArray):
         da = ds
     else:

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,6 @@ dependencies:
  - pyproj>=2.5
  - requests>=2.0
  - roocs-utils>=0.3.0
- - cf_xarray>=0.3.1
+ - cf_xarray>=0.5.1
 #  - pip:
 #     - roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pyproj>=2.5
 bottleneck~=1.3.1
 requests>=2.0
 roocs-utils>=0.3.0
-cf-xarray>=0.3.1
+cf-xarray>=0.5.1
 # roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,7 +172,7 @@ def ndq_series():
 
 @pytest.fixture
 def areacella():
-    """Return a rectangular grid of grid cell area. """
+    """Return a rectangular grid of grid cell area."""
     r = 6100000
     lon_bnds = np.arange(-180, 181, 1)
     lat_bnds = np.arange(-90, 91, 1)

--- a/tests/core/test_average.py
+++ b/tests/core/test_average.py
@@ -1,4 +1,5 @@
 import os
+from pkg_resources import parse_version
 
 import geopandas as gpd
 import numpy as np
@@ -13,6 +14,8 @@ from .._common import XCLIM_TESTS_DATA as TESTS_DATA
 
 try:
     import xesmf
+    if parse_version(xesmf.__version__) < parse_version("0.5.2"):
+        raise ImportError
 except ImportError:
     xesmf = None
 
@@ -79,6 +82,13 @@ class TestAverageShape:
             avg.isel(time=0), [268.30972367, 277.23981999, 277.58614891]
         )
         np.testing.assert_array_equal(avg.geom, ["Québec", "Europe", "Newfoundland"])
+
+    def test_non_overlapping_regions(self):
+        ds = xr.open_dataset(self.nc_file_neglons)
+        regions = gpd.read_file(self.meridian_geojson)
+
+        with pytest.raises(ValueError):
+            average.average_shape(ds.tasmax, shape=regions)
 
 
 class TestAverageOverDims:

--- a/tests/core/test_average.py
+++ b/tests/core/test_average.py
@@ -1,10 +1,10 @@
 import os
-from pkg_resources import parse_version
 
 import geopandas as gpd
 import numpy as np
 import pytest
 import xarray as xr
+from pkg_resources import parse_version
 from roocs_utils.exceptions import InvalidParameterValue
 
 from clisops.core import average
@@ -14,6 +14,7 @@ from .._common import XCLIM_TESTS_DATA as TESTS_DATA
 
 try:
     import xesmf
+
     if parse_version(xesmf.__version__) < parse_version("0.5.2"):
         raise ImportError
 except ImportError:

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -42,7 +42,7 @@ def _load_ds(fpath):
 
 
 def test_subset_no_params(cmip5_tas_file, tmpdir):
-    """ Test subset without area param."""
+    """Test subset without area param."""
     result = subset(
         ds=cmip5_tas_file,
         output_dir=tmpdir,
@@ -53,7 +53,7 @@ def test_subset_no_params(cmip5_tas_file, tmpdir):
 
 
 def test_subset_time(cmip5_tas_file, tmpdir):
-    """ Tests clisops subset function with a time subset."""
+    """Tests clisops subset function with a time subset."""
     result = subset(
         ds=cmip5_tas_file,
         time=("2005-01-01T00:00:00", "2020-12-30T00:00:00"),
@@ -84,7 +84,7 @@ def test_subset_args_as_parameter_classes(cmip5_tas_file, tmpdir):
 
 
 def test_subset_invalid_time(cmip5_tas_file, tmpdir):
-    """ Tests subset with invalid time param."""
+    """Tests subset with invalid time param."""
     with pytest.raises(InvalidParameterValue):
         subset(
             ds=cmip5_tas_file,
@@ -97,7 +97,7 @@ def test_subset_invalid_time(cmip5_tas_file, tmpdir):
 
 
 def test_subset_ds_is_none(tmpdir):
-    """ Tests subset with ds=None."""
+    """Tests subset with ds=None."""
     with pytest.raises(MissingParameterValue):
         subset(
             ds=None,
@@ -108,7 +108,7 @@ def test_subset_ds_is_none(tmpdir):
 
 
 def test_subset_no_ds(tmpdir):
-    """ Tests subset with no dataset provided."""
+    """Tests subset with no dataset provided."""
     with pytest.raises(TypeError):
         subset(
             time=("2020-01-01T00:00:00", "2020-12-30T00:00:00"),
@@ -118,7 +118,7 @@ def test_subset_no_ds(tmpdir):
 
 
 def test_subset_area_simple_file_name(cmip5_tas_file, tmpdir):
-    """ Tests clisops subset function with a area subset (simple file name)."""
+    """Tests clisops subset function with a area subset (simple file name)."""
     result = subset(
         ds=cmip5_tas_file,
         area=(0.0, 10.0, 10.0, 65.0),
@@ -130,7 +130,7 @@ def test_subset_area_simple_file_name(cmip5_tas_file, tmpdir):
 
 
 def test_subset_area_project_file_name(cmip5_tas_file, tmpdir):
-    """ Tests clisops subset function with a area subset (derived file name)."""
+    """Tests clisops subset function with a area subset (derived file name)."""
     result = subset(
         ds=cmip5_tas_file,
         area=(0.0, 10.0, 10.0, 65.0),
@@ -142,7 +142,7 @@ def test_subset_area_project_file_name(cmip5_tas_file, tmpdir):
 
 
 def test_subset_invalid_area(cmip5_tas_file, tmpdir):
-    """ Tests subset with invalid area param."""
+    """Tests subset with invalid area param."""
     with pytest.raises(InvalidParameterValue):
         subset(
             ds=cmip5_tas_file,
@@ -247,7 +247,7 @@ def test_subset_4D_data_all_argument_permutations(load_esgf_test_data, tmpdir):
 
 
 def test_subset_with_multiple_files_tas(load_esgf_test_data, tmpdir):
-    """ Tests with multiple tas files"""
+    """Tests with multiple tas files"""
     result = subset(
         ds=CMIP5_TAS,
         time=("2001-01-01T00:00:00", "2020-12-30T00:00:00"),
@@ -260,7 +260,7 @@ def test_subset_with_multiple_files_tas(load_esgf_test_data, tmpdir):
 
 
 def test_subset_with_multiple_files_zostoga(load_esgf_test_data, tmpdir):
-    """ Tests with multiple zostoga files"""
+    """Tests with multiple zostoga files"""
     result = subset(
         ds=CMIP5_ZOSTOGA,
         time=("2000-01-01T00:00:00", "2020-12-30T00:00:00"),
@@ -272,7 +272,7 @@ def test_subset_with_multiple_files_zostoga(load_esgf_test_data, tmpdir):
 
 
 def test_subset_with_multiple_files_rh(load_esgf_test_data, tmpdir):
-    """ Tests with multiple rh files"""
+    """Tests with multiple rh files"""
     result = subset(
         ds=CMIP5_RH,
         time=("2005-01-01T00:00:00", "2020-12-30T00:00:00"),
@@ -285,7 +285,7 @@ def test_subset_with_multiple_files_rh(load_esgf_test_data, tmpdir):
 
 
 def test_subset_with_tas_series(tmpdir, tas_series):
-    """ Test with tas_series fixture"""
+    """Test with tas_series fixture"""
     result = subset(
         ds=tas_series(["20", "22", "25"]),
         time=("2000-07-01T00:00:00", "2020-12-30T00:00:00"),
@@ -449,7 +449,7 @@ def test_area_within_area_subset_chunked(load_esgf_test_data):
 
 
 def test_subset_level(cmip6_o3):
-    """ Tests clisops subset function with a level subset."""
+    """Tests clisops subset function with a level subset."""
     # Levels are: 100000, ..., 100
     ds = _load_ds(cmip6_o3)
 
@@ -606,7 +606,7 @@ def test_time_invariant_subset_standard_name(load_esgf_test_data, tmpdir):
 
 
 def test_longitude_and_latitude_coords_only(load_esgf_test_data, tmpdir):
-    """ Test subset suceeds when latitude and longitude are coordinates not dims and are not called lat/lon """
+    """Test subset suceeds when latitude and longitude are coordinates not dims and are not called lat/lon"""
 
     result = subset(
         ds=CMIP6_TOS,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39}-xesmf, black, py37-windows, macOS, docs
+envlist = py{36,37,38,39}-xesmf, black, py37-windows, macOS, docs
 requires = pip >= 20.0
 opts = -v
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{36,37,38,39}, black, py37-windows, macOS, docs
+envlist = py{37,38,39}-xesmf, black, py37-windows, macOS, docs
 requires = pip >= 20.0
 opts = -v
 
 [travis]
 python =
-    3.6: black
-    3.6: docs
+    3.7: black
+    3.7: docs
 
 [testenv:black]
 skip_install = True
@@ -40,5 +40,6 @@ deps =
     pytest-cov
     pip
 commands =
+    xesmf: pip install --upgrade git+https://github.com/pangeo-data/xESMF.git
     pytest --cov clisops
     - coveralls


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #163 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->

This PR forces the spatial averaging function to fail early if there is no overlapping values. I also updated `cf-xarray` as my environment that used v0.3.1 was having runtime errors. To make things simpler, I added a condition in the averaging test to fail the `xesmf` import if the version is older than '0.5.2'. Finally, I updated the tox recipes to drop Python3.6, and to allow us to install xesmf from GitHub source, if ever we want to use it instead.

In the name of good housekeeping, I've also updated the pre-commit dependencies and re-run `black`. The newest version of it can fix slightly malformed docstrings, so that's a nice bonus.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->

Yes. If there is no overlap, this will no longer return an array that resolves to `[0]` and will raise a `ValueError` instead.

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->

https://github.com/psf/black/releases/tag/21.4b0
https://github.com/psf/black/releases/tag/21.4b1
https://github.com/psf/black/releases/tag/21.4b2
