### PR TITLE
Update the CI setup to use multi-stage build and Anaconda

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -88,7 +88,7 @@ Ready to contribute? Here's how to set up `clisops` for local development.
     # For Anaconda/Miniconda environments:
     $ conda install -c conda-forge black pytest tox
 
-    $ black clisops tests
+    $ black --target-python py36 clisops tests
     $ python setup.py test
     $ tox
 
@@ -109,7 +109,7 @@ Ready to contribute? Here's how to set up `clisops` for local development.
     $ git commit -m "Your detailed description of your changes."
     # `pre-commit` will run checks at this point:
     # if no errors are found, changes will be committed.
-    # if errors are found, modifications will be mades. Simply `git commit` again.
+    # if errors are found, modifications will be made. Simply `git commit` again.
 
     $ git push origin name-of-your-bugfix-or-feature
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,5 +69,4 @@ jobs:
       - name: Test with conda
         run: |
             source activate clisops
-            pip install --upgrade git+https://github.com/pangeo-data/xESMF.git
             pytest --cov tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,7 @@ jobs:
             conda env create -f environment.yml
             source activate clisops
             pip install -e ".[dev]"
+            pip install --upgrade git+https://github.com/pangeo-data/xESMF.git
       - name: Test with conda
         run: |
             source activate clisops

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,39 +1,73 @@
 name: build
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
-  build:
-
+  black:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        tox-env: [black]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install tox
+        run: pip install tox
+      - name: Run linting suite
+        run: tox -e ${{ matrix.tox-env }}
+
+  pypi:
+    needs: black
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - python-version: 3.6
+            tox-env: py36
+          - python-version: 3.7
+            tox-env: py37
+          - python-version: 3.8
+            tox-env: py38
+          - python-version: 3.9
+            tox-env: py39
     steps:
     - uses: actions/checkout@v2
-    - name: Install packages
-      run: |
-        sudo apt-get -y install pandoc
-      if: matrix.python-version == 3.6
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        # pip install flake8 black pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
-    - name: Lint with flake8
-      run: flake8 clisops tests
-      if: matrix.python-version == 3.6
-    - name: Check formatting with black
-      run: black --check --target-version py36 clisops tests
-      if: matrix.python-version == 3.6
-    - name: Test with pytest
-      run: |
-        pytest -v tests
-    - name: Build docs 🏗️
-      run: make docs
-      if: matrix.python-version == 3.6
+    - name: Install tox
+      run: pip install tox
+    - name: Test with tox
+      run: tox -e ${{ matrix.tox-env }}
+
+  conda-xesmf:
+    needs: black
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup conda with Python ${{ matrix.python-version }}
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          python-version: ${{ matrix.python-version }}
+          conda-channels: conda-forge, defaults
+      - name: Conda env configuration
+        run: |
+            conda env create -f environment.yml
+            source activate clisops
+            pip install -e ".[dev]"
+      - name: Test with conda
+        run: |
+            source activate clisops
+            pip install --upgrade git+https://github.com/pangeo-data/xESMF.git
+            pytest --cov tests

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,8 +17,8 @@ New Features
 
 Other Changes
 ^^^^^^^^^^^^^
-* clisops logging no longer disbales other loggers.
-
+* clisops logging no longer disables other loggers.
+* GitHub CI now leverages ``tox`` for testing as well as tests averaging functions via a conda-based build.
 
 v0.6.3 (2021-03-30)
 -------------------

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ wheel
 watchdog
 flake8
 tox
-coverage
+pytest-cov
 Sphinx
 sphinx-rtd-theme
 twine

--- a/tox.ini
+++ b/tox.ini
@@ -41,5 +41,5 @@ deps =
     pip
 commands =
     xesmf: pip install --upgrade git+https://github.com/pangeo-data/xESMF.git
-    pytest --cov clisops
+    pytest --cov tests
     - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-xesmf, black, py37-windows, macOS, docs
+envlist = py{36,37,38,39}, black, py37-windows, macOS, docs
 requires = pip >= 20.0
 opts = -v
 
@@ -40,6 +40,5 @@ deps =
     pytest-cov
     pip
 commands =
-    xesmf: pip install --upgrade git+https://github.com/pangeo-data/xESMF.git
     pytest --cov tests
     - coveralls


### PR DESCRIPTION
Update the github actions to use a black initial step and a conda-forge build step for testing spatial averaging functions

<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->

This PR makes GitHub's CI leverage tox for soem of the build testing and breaks the testing into a few steps. Tests must pass code linting check --> triggers Python3.{6,7,8,9} builds with `tox`, as well as a conda-based Python3.8 build for testing the SpatialAveraging tools with `xESMF`@master.

I also removed the docs build steps, as ReadTheDocs is already handling that portion of the CI testing.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->

No, in fact, before this was set up, the CI ensemble was skipping the averaging tests as they only run from an Anaconda-based python environment (xESMF is not on PyPI).

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
