### PR TITLE
Copy `file_md5_checksum` deprecated in xarray 0.18

### DIFF
--- a/clisops/utils/tutorial.py
+++ b/clisops/utils/tutorial.py
@@ -1,5 +1,6 @@
 """Testing and tutorial utilities module."""
 # Most of this code copied and adapted from xarray, xclim, and raven
+import hashlib
 import logging
 import re
 from pathlib import Path
@@ -11,13 +12,19 @@ from urllib.request import urlretrieve
 import requests
 from xarray import Dataset
 from xarray import open_dataset as _open_dataset
-from xarray.tutorial import file_md5_checksum
 
 _default_cache_dir = Path.home() / ".clisops_testing_data"
 
 LOGGER = logging.getLogger(__file__)
 
 __all__ = ["get_file", "open_dataset", "query_folder"]
+
+
+def file_md5_checksum(fname):
+    hash_md5 = hashlib.md5()
+    with open(fname, "rb") as f:
+        hash_md5.update(f.read())
+    return hash_md5.hexdigest()
 
 
 def _get(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #155
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Copies the `file_md5_checksum` function into `utils.tutorial` because it has been removed (without warnings) from xarray 0.18, which was released yesterday.  In fact their whole "test dataset" retrieval code now makes use of `pooch`, instead of the manual in-house code that we copied here and in xclim. At xclim we decided it was not worth our time (for now) to also make this move: if it works don't fix it.

This copy is a minimal change that makes it work again.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
I would suggest to add a build against xarray@master, if it ain't too much trouble. It could help detect those issues earlier.
