### PR TITLE
Improve performance of create_mask

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Version History
 ===============
 
+v0.6.5 (unreleased)
+-------------------
+
+New Features
+^^^^^^^^^^^^
+* New optional dependency ``PyGEOS``, when installed the performance of ``core.subset.create_mask`` and ``cure.subset.subset_shape`` are greatly improved.
+
 v0.6.4 (2021-05-17)
 -------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,6 +29,9 @@ you through the process.
    on packages (ESMF, ESMpy) unavailable on windows.  It can still be installed on osx/linux through `conda` or
    directly [from source](https://github.com/pangeo-data/xESMF/).
 
+Another optional dependency is [pygeos](https://pygeos.readthedocs.io/en/latest/index.html). If installed,
+the performance of `core.subset.create_mask` and `core.subset.subset_shape` are greatly improved.
+
 From sources
 ------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -19,5 +19,6 @@ dependencies:
  - requests>=2.0
  - roocs-utils>=0.3.0
  - cf_xarray>=0.5.1
+ - pygeos>=0.8
 #  - pip:
 #     - roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,7 @@ docs_requirements = [
     "matplotlib",
 ]
 
-extra_requirements = [
-    "xesmf>=0.5.2",
-]
+extra_requirements = ["xesmf>=0.5.2", "pygeos>=0.8"]
 
 setup(
     version=about["__version__"],

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -16,6 +16,27 @@ try:
 except ImportError:
     xesmf = None
 
+try:
+    import pygeos
+except ImportError:
+    pygeos = None
+
+
+@pytest.fixture(params=[True, False])
+def toggle_pygeos(request):
+    if request.param:
+        if pygeos is None:
+            pytest.skip("pygeos not installed")
+        else:
+            yield request.param
+    else:
+        # Do not use pygeos
+        mod = subset.pygeos
+        # Monkeypatch core.subset to imitate the absence of pygeos.
+        subset.pygeos = None
+        yield request.param
+        subset.pygeos = mod
+
 
 class TestSubsetTime:
     nc_poslons = get_file("cmip3/tas.sresb1.giss_model_e_r.run1.atm.da.nc")
@@ -795,7 +816,7 @@ class TestSubsetShape:
         with xr.open_dataset(filename_or_obj=tmp_netcdf_filename) as f:
             assert {"tas", "crs"}.issubset(set(f.data_vars))
 
-    def test_mask_multiregions(self):
+    def test_mask_multiregions(self, toggle_pygeos):
         ds = xr.open_dataset(self.nc_file)
         regions = gpd.read_file(self.multi_regions_geojson)
         regions.set_index("id")
@@ -827,7 +848,7 @@ class TestSubsetShape:
         assert ds_sub.notnull().sum() == 58 + 250 + 22
         assert ds_sub.tas.shape == (12, 14, 128)
 
-    def test_vectorize_touches_polygons(self):
+    def test_vectorize_touches_polygons(self, toggle_pygeos):
         """Check that points touching the polygon are included in subset."""
         # Create simple polygon
         poly = Polygon([[0, 0], [1, 0], [1, 1]])

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -898,9 +898,8 @@ def test_end_date_nudged_backwards():
     # check end date normally raises an error
     with pytest.raises(ValueError) as exc:
         ds.time.sel(time=slice(None, end_date))
-    assert (
-        str(exc.value)
-        == "invalid day number provided in cftime.DatetimeNoLeap(2012, 2, 29, 12, 0, 0, 0)"
+    assert str(exc.value).startswith(
+        "invalid day number provided in cftime.DatetimeNoLeap(2012, 2, 29, 12, 0, 0, 0"
     )
 
     result = subset(
@@ -924,9 +923,8 @@ def test_start_date_nudged_forwards():
     # check start date normally raises an error
     with pytest.raises(ValueError) as exc:
         ds.time.sel(time=slice(None, start_date))
-    assert (
-        str(exc.value)
-        == "invalid day number provided in cftime.DatetimeNoLeap(2012, 2, 29, 12, 0, 0, 0)"
+    assert str(exc.value).startswith(
+        "invalid day number provided in cftime.DatetimeNoLeap(2012, 2, 29, 12, 0, 0, 0"
     )
 
     result = subset(
@@ -950,9 +948,8 @@ def test_end_date_nudged_backwards_monthly_data():
     # check end date normally raises an error
     with pytest.raises(ValueError) as exc:
         ds.time.sel(time=slice(None, end_date))
-    assert (
-        str(exc.value)
-        == "invalid day number provided in cftime.DatetimeNoLeap(2012, 2, 29, 12, 0, 0, 0)"
+    assert str(exc.value).startswith(
+        "invalid day number provided in cftime.DatetimeNoLeap(2012, 2, 29, 12, 0, 0, 0"
     )
 
     result = subset(
@@ -976,9 +973,8 @@ def test_start_date_nudged_backwards_monthly_data():
     # check start date normally raises an error
     with pytest.raises(ValueError) as exc:
         ds.time.sel(time=slice(None, start_date))
-    assert (
-        str(exc.value)
-        == "invalid day number provided in cftime.DatetimeNoLeap(2012, 2, 29, 12, 0, 0, 0)"
+    assert str(exc.value).startswith(
+        "invalid day number provided in cftime.DatetimeNoLeap(2012, 2, 29, 12, 0, 0, 0"
     )
 
     result = subset(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #160
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Adds `PyGEOS` as an optional dependency. In `create_mask`, when it imported the intersection between the points and the current polygon is computed using its `covers` function, which is equivalent to touches+contains, but with the same performance as contains alone. 

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No.

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
I also modified the tests in `ops/test_subset.py` so that they pass with `cftime==1.5.0`. 