### PR TITLE
Fix for xESMF 0.6.1

### DIFF
--- a/clisops/core/average.py
+++ b/clisops/core/average.py
@@ -75,7 +75,12 @@ def average_shape(
         poly = poly.to_crs(4326)
 
     savger = SpatialAverager(ds_copy, poly.geometry)
-    if savger.weights.nnz == 0:
+    nonnull = (
+        savger.weights.data.nnz
+        if isinstance(savger.weights, xr.DataArray)
+        else savger.weights.nnz
+    )
+    if nonnull == 0:
         raise ValueError(
             "There were no valid data points found in the requested averaging region. Verify objects overlap."
         )


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Minimal change to adapt to new xESMF 0.6.1. In that version, the `weights` attribute of the Regridder object is a DataArray, instead of a scipy sparse matrix. The change is retrocompatible.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
