### PR TITLE
Update xesmf minimal version to 0.6.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,4 +74,4 @@ jobs:
         run: |
             source activate clisops
             pytest --cov tests
-        continue-on-error: true
+        continue-on-error: false

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,10 @@ Bug fixes
 ---------
 * ``average_shape`` and ``create_weight_masks`` were adapted to work with xESMF 0.6.1, while maintaining compatibility with earlier versions.
 
+Other Changes
+^^^^^^^^^^^^^
+* Minimum xesmf version set to 0.6.2.
+
 v0.7.0 (2021-10-26)
 -------------------
 

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -621,7 +621,7 @@ def create_weight_masks(
         from xesmf import SpatialAverager
     except ImportError:
         raise ValueError(
-            "Package xesmf >= 0.5.2 is required to use create_weight_masks"
+            "Package xesmf >= 0.6.2 is required to use create_weight_masks"
         )
 
     if poly.crs is not None:

--- a/clisops/etc/logging.conf
+++ b/clisops/etc/logging.conf
@@ -8,7 +8,7 @@ keys=consoleHandler
 keys=simpleFormatter
 
 [logger_root]
-level=DEBUG
+level=INFO
 handlers=consoleHandler
 
 [logger_simpleExample]

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - pandas>=1.0.3
 - cftime>=1.4.1
 - netCDF4>=1.4
-- xesmf>=0.5.2
+- xesmf>=0.6.2
 - poppler>=0.67
 - shapely>=1.6
 - geopandas>=0.7

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
  - poppler>=0.67
  - shapely>=1.6
  - geopandas>=0.7
- - xesmf>=0.5.2,<=0.6
+ - xesmf>=0.6.2
  - dask>=2.6.0
  - bottleneck>=1.3.1,<1.4
  - pyproj>=2.5

--- a/notebooks/core_subset.ipynb
+++ b/notebooks/core_subset.ipynb
@@ -745,7 +745,7 @@
     "\n",
     "While `create_mask` (and `subset_shape`) only check if the center of a grid cell lies inside of a polygon or not, `create_weight_masks` (and `average_shape`, see the Average utilities notebook) consider the partial overlap of grid cells and polygons. Thus, instead of creating an integer mask for the data, this method creates one mask for each polygon. The weights are the fraction of the grid cells-polygon overlap over the whole polygon. As such, the sum along spatial dimensions gives 1 for each geometry.\n",
     "\n",
-    "However, this feature of clisops requires the optional xESMF dependcy (version 0.5.2 or later), which is not currently available of pypi (`pip`) and must be installed either through `conda` or from the source.\n",
+    "However, this feature of clisops requires the optional xESMF dependency (version 0.6.2 or later), which is not currently available of pypi (`pip`) and must be installed either through `conda` or from the source.\n",
     "\n",
     "The call signature is different: a dataset or dataarray containing the grid information is passed directly. The [same restrictions as for xESMF](https://pangeo-xesmf.readthedocs.io/en/latest/user_api.html#xesmf.frontend.SpatialAverager) apply."
    ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ["setup.py"]
-#addopts = --verbose tests
+addopts = --verbose tests
 filterwarnings =
 	ignore::UserWarning
 markers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ replace = version = "{new_version}"
 universal = 1
 
 [flake8]
-exclude = 
+exclude =
 	.git,
 	docs,
 	build,
@@ -23,7 +23,7 @@ exclude =
 	tests/mini-esgf-data
 max-line-length = 88
 max-complexity = 12
-ignore = 
+ignore =
 	C901
 	E203
 	E231
@@ -41,16 +41,16 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ["setup.py"]
-addopts = --verbose tests
-filterwarnings = 
+#addopts = --verbose tests
+filterwarnings =
 	ignore::UserWarning
-markers = 
+markers =
 	online: mark test to need internet connection
 	slow: mark test to be slow
 
 [pylint]
 ignore = docs,tests
-disable = 
+disable =
 	too-many-arguments,
 	too-few-public-methods,
 	invalid-name,

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ docs_requirements = [
     "matplotlib",
 ]
 
-extra_requirements = ["xesmf>=0.5.2", "pygeos>=0.8"]
+extra_requirements = ["xesmf>=0.6.2", "pygeos>=0.8"]
 
 setup(
     version=about["__version__"],

--- a/tests/core/test_average.py
+++ b/tests/core/test_average.py
@@ -15,13 +15,13 @@ from .._common import XCLIM_TESTS_DATA as TESTS_DATA
 try:
     import xesmf
 
-    if parse_version(xesmf.__version__) < parse_version("0.5.2"):
+    if parse_version(xesmf.__version__) < parse_version("0.6.2"):
         raise ImportError
 except ImportError:
     xesmf = None
 
 
-@pytest.mark.skipif(xesmf is None, reason="xESMF >= 0.5.2 is needed for average_shape.")
+@pytest.mark.skipif(xesmf is None, reason="xESMF >= 0.6.2 is needed for average_shape.")
 class TestAverageShape:
     nc_file = get_file("cmip5/tas_Amon_CanESM2_rcp85_r1i1p1_200701-200712.nc")
     lons_2d_nc_file = get_file("cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc")

--- a/tests/core/test_average.py
+++ b/tests/core/test_average.py
@@ -47,11 +47,11 @@ class TestAverageShape:
         assert len(avg.time) == 12
 
         # Average temperature at surface for region in January (time=0)
-        np.testing.assert_array_almost_equal(avg.isel(time=0), 284.98243933)
+        np.testing.assert_array_almost_equal(avg.isel(time=0), 285.533, 3)
 
         poly = gpd.read_file(self.meridian_multi_geojson)
         avg = average.average_shape(ds.tas, poly)
-        np.testing.assert_array_almost_equal(avg.isel(time=0), 280.67990737)
+        np.testing.assert_array_almost_equal(avg.isel(time=0), 280.965, 3)
 
     def test_no_wraps(self, tmp_netcdf_filename):
         ds = xr.open_dataset(self.nc_file)
@@ -62,7 +62,7 @@ class TestAverageShape:
         assert len(avg.time) == 12
 
         # Average temperature at surface for region in January (time=0)
-        np.testing.assert_array_almost_equal(avg.isel(time=0), 276.17126511)
+        np.testing.assert_array_almost_equal(avg.isel(time=0), 276.152, 3)
 
     def test_all_neglons(self):
         ds = xr.open_dataset(self.nc_file_neglons)
@@ -70,7 +70,7 @@ class TestAverageShape:
         avg = average.average_shape(ds.tasmax, self.southern_qc_geojson)
 
         # Average temperature at surface for region in January (time=0)
-        np.testing.assert_array_almost_equal(avg.isel(time=0), 269.25454934)
+        np.testing.assert_array_almost_equal(avg.isel(time=0), 269.257, 3)
 
     # 2D lat/lon grids are buggy with current xesmf
     # def test_rotated_pole_with_time(self):
@@ -83,7 +83,7 @@ class TestAverageShape:
         regions = gpd.read_file(self.multi_regions_geojson).set_index("id")
         avg = average.average_shape(ds.tas, shape=regions)
         np.testing.assert_array_almost_equal(
-            avg.isel(time=0), [268.30972367, 277.23981999, 277.58614891], decimal=5
+            avg.isel(time=0), [268.620, 278.290, 277.863], decimal=3
         )
         np.testing.assert_array_equal(avg.geom, ["Québec", "Europe", "Newfoundland"])
 

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -828,7 +828,7 @@ class TestSubsetShape:
         assert all(counts == [58, 250, 22])
 
     @pytest.mark.skipif(
-        xesmf is None, reason="xESMF >= 0.5.2 is needed for average_shape."
+        xesmf is None, reason="xESMF >= 0.6.2 is needed for average_shape."
     )
     def test_weight_masks_multiregions(self):
         # rename is due to a small limitation of xESMF 0.5.2

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -838,7 +838,7 @@ class TestSubsetShape:
 
         np.testing.assert_allclose(masks.sum(["lat", "lon"]), [1, 1, 1])
         np.testing.assert_array_equal(masks.geom.values, regions.index)
-        np.testing.assert_allclose(masks.max("geom").sum(), 2.900397)
+        np.testing.assert_allclose(masks.max("geom").sum(), 2.900, 3)
 
     def test_subset_multiregions(self):
         ds = xr.open_dataset(self.nc_file)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
- Update xesmf to 0.6.2
- Update expected values for `average_shape` output. 
- Sets `logger_root` log level to INFO instead of DEBUG. numba logging made test outputs unreadable.
- conda-xesmf action workflow will fail if any CI test fails.


* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
Should not. Fixes a bug in the SpatialAverager weights. 

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
Fixes #206.