### PR TITLE
Do not build EPUB on ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,8 @@ sphinx:
   fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+formats:
+    - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,12 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(".."))
+import xarray
 
-import sphinx_rtd_theme
+xarray.DataArray.__module__ = "xarray"
+xarray.Dataset.__module__ = "xarray"
+
+sys.path.insert(0, os.path.abspath(".."))
 
 # -- General configuration ---------------------------------------------
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->

* Drop EPUB support for CLISOPS on ReadTheDocs

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->

No.

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->

EPUB file does not fully support Jupyter Notebooks, so building them causes fail-producing warnings.
