### PR TITLE
Fix xarray deprecation, docstring examples, and some type hinting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
       - uses: actions/checkout@v3
       - name: Setup conda with Python ${{ matrix.python-version }}
@@ -76,6 +76,10 @@ jobs:
             mamba env create -f environment.yml
             source activate clisops
             pip install -e ".[dev]"
+      - name: Install xarray@main
+        run: |
+            source activate clisops
+            pip install git+https://github.com/pydata/xarray.git@main#egg=xarray
       - name: Test with conda
         run: |
             source activate clisops

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,19 @@
 Version History
 ===============
 
+v0.9.3 (unreleased)
+-------------------
+
+Bug Fixes
+---------
+* Fixed a bug associated with the new xarray (2022.6.0+) accessor for native indexers that was introduced in (#241). (#250, #251).
+
+Other Changes
+-------------
+* Fixed a handful of static type hints that were sending out warnings, despite proper use. (#251).
+* Replaced all skipped doctests with sphinx-compatible python code blocks to prevent errors in downstream projects. (#251).
+* Adjusted GitHub Actions builds to ensure that the `conda-xesmf` run uses the lastest `xarray` available. (#251).
+
 v0.9.2 (2022-09-06)
 -------------------
 

--- a/clisops/core/average.py
+++ b/clisops/core/average.py
@@ -143,7 +143,7 @@ def average_shape(
 
 def average_over_dims(
     ds: Union[xr.DataArray, xr.Dataset],
-    dims: Tuple[str] = None,
+    dims: Sequence[str] = None,
     ignore_undetected_dims: bool = False,
 ) -> Union[xr.DataArray, xr.Dataset]:
     """
@@ -153,7 +153,7 @@ def average_over_dims(
     ----------
     ds : Union[xr.DataArray, xr.Dataset]
         Input values.
-    dims : Tuple[{"time", "level", "latitude", "longitude"}]
+    dims : Sequence[{"time", "level", "latitude", "longitude"}]
         The dimensions over which to apply the average. If None, none of the dimensions are averaged over. Dimensions
         must be one of ["time", "level", "latitude", "longitude"].
     ignore_undetected_dims : bool

--- a/clisops/core/average.py
+++ b/clisops/core/average.py
@@ -3,7 +3,7 @@ import warnings
 from pathlib import Path
 from typing import Sequence, Tuple, Union
 
-import cf_xarray
+import cf_xarray  # noqa
 import geopandas as gpd
 import numpy as np
 import xarray as xr
@@ -37,19 +37,19 @@ def average_shape(
     Parameters
     ----------
     ds : xarray.Dataset
-      Input values, coordinate attributes must be CF-compliant.
+        Input values, coordinate attributes must be CF-compliant.
     shape : Union[str, Path, gpd.GeoDataFrame]
-      Path to shape file, or directly a geodataframe. Supports formats compatible with geopandas.
-      Will be converted to EPSG:4326 if needed.
+        Path to shape file, or directly a geodataframe. Supports formats compatible with geopandas.
+        Will be converted to EPSG:4326 if needed.
     variable : Union[str, Sequence[str], None]
-      Variables to average. If None, average over all data variables.
+        Variables to average. If None, average over all data variables.
 
     Returns
     -------
     Union[xarray.DataArray, xarray.Dataset]
-      `ds` spatially-averaged over the polygon(s) in `shape`.
-      Has a new `geom` dimension corresponding to the index of the input geodataframe.
-      Non-geometry columns of the geodataframe are copied as auxiliary coordinates.
+        `ds` spatially-averaged over the polygon(s) in `shape`.
+        Has a new `geom` dimension corresponding to the index of the input geodataframe.
+        Non-geometry columns of the geodataframe are copied as auxiliary coordinates.
 
     Notes
     -----
@@ -62,16 +62,19 @@ def average_shape(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.average import average_shape  # doctest: +SKIP
-    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-    ...
-    # Average data array over shape
-    >>> prAvg = average_shape(pr, shape=path_to_shape_file)  # doctest: +SKIP
-    ...
-    # Average multiple variables in a single dataset
-    >>> ds = xr.open_mfdataset([path_to_tasmin_file, path_to_tasmax_file])  # doctest: +SKIP
-    >>> dsAvg = average_shape(ds, shape=path_to_shape_file)  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr  # doctest: +SKIP
+        from clisops.core.average import average_shape
+
+        pr = xr.open_dataset(path_to_pr_file).pr
+
+        # Average data array over shape
+        prAvg = average_shape(pr, shape=path_to_shape_file)
+
+        # Average multiple variables in a single dataset
+        ds = xr.open_mfdataset([path_to_tasmin_file, path_to_tasmax_file])
+        dsAvg = average_shape(ds, shape=path_to_shape_file)
     """
     try:
         from xesmf import SpatialAverager
@@ -149,27 +152,30 @@ def average_over_dims(
     Parameters
     ----------
     ds : Union[xr.DataArray, xr.Dataset]
-      Input values.
-    dims : Tuple[str] = None
-      The dimensions over which to apply the average. If None, none of the dimensions are averaged over. Dimensions
-      must be one of ["time", "level", "latitude", "longitude"].
-    ignore_undetected_dims: bool
-      If the dimensions specified are not found in the dataset, an Exception will be raised if set to True.
-      If False, an exception will not be raised and the other dimensions will be averaged over. Default = False
+        Input values.
+    dims : Tuple[{"time", "level", "latitude", "longitude"}]
+        The dimensions over which to apply the average. If None, none of the dimensions are averaged over. Dimensions
+        must be one of ["time", "level", "latitude", "longitude"].
+    ignore_undetected_dims : bool
+        If the dimensions specified are not found in the dataset, an Exception will be raised if set to True.
+        If False, an exception will not be raised and the other dimensions will be averaged over. Default = False
 
     Returns
     -------
     Union[xr.DataArray, xr.Dataset]
-      New Dataset or DataArray object averaged over the indicated dimensions.
-      The indicated dimensions will have been removed.
+        New Dataset or DataArray object averaged over the indicated dimensions.
+        The indicated dimensions will have been removed.
 
     Examples
     --------
-    >>> from clisops.core.average import average_over_dims  # doctest: +SKIP
-    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-    ...
-    # Average data array over latitude and longitude
-    >>> prAvg = average_over_dims(pr, dims=['latitude', 'longitude'], ignore_undetected_dims=True)  # doctest: +SKIP
+    .. code-block:: python
+
+        from clisops.core.average import average_over_dims
+
+        pr = xr.open_dataset(path_to_pr_file).pr
+
+        # Average data array over latitude and longitude
+        prAvg = average_over_dims(pr, dims=['latitude', 'longitude'], ignore_undetected_dims=True)
     """
 
     if not dims:
@@ -251,11 +257,14 @@ def average_time(
 
     Examples
     --------
-    >>> from clisops.core.average import average_time  # doctest: +SKIP
-    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-    ...
-    # Average data array over each month
-    >>> prAvg = average_time(pr, freq='month')  # doctest: +SKIP
+    .. code-block:: python
+
+        from clisops.core.average import average_time
+
+        pr = xr.open_dataset(path_to_pr_file).pr
+
+        # Average data array over each month
+        prAvg = average_time(pr, freq='month')
     """
 
     if not freq:

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -798,7 +798,7 @@ def shape_bbox_indexer(ds, poly):
         else:
             native_ind = xarray.core.indexing.map_index_queries(
                 ds, ind, method="nearest"
-            ).indexers
+            ).dim_indexers
     else:
         # For curvilinear grids, finding the closest points require a bit more work.
         # Note that this code is not exercised for now.

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -404,7 +404,7 @@ def wrap_lons_and_split_at_greenwich(func):
 
         if wrap_lons:
             if (np.min(x_dim) < 0 and np.max(x_dim) >= 360) or (
-                np.min(x_dim) < -180 and np.max >= 180
+                np.min(x_dim) < -180 and np.max(x_dim) >= 180
             ):
                 # TODO: This should raise an exception, right?
                 warnings.warn(
@@ -488,7 +488,7 @@ def create_mask(
     y_dim : xarray.DataArray
         Y or latitudinal dimension of xarray object. Can also be given through `ds_in`.
     poly : gpd.GeoDataFrame
-        GeoDataFrame used to create the xarray.DataArray mask. If its index doesn't have a
+        A GeoDataFrame used to create the xarray.DataArray mask. If its index doesn't have an
         integer dtype, it will be reset to integers, which will be used in the mask.
     wrap_lons : bool
         Shift vector longitudes by -180,180 degrees to 0,360 degrees; Default = False
@@ -697,6 +697,8 @@ def _curvilinear_grid_exterior_polygon(ds, mode="bbox"):
         x, y = np.around(pts.xy, 1)
         y = np.clip(y, -90, 90)
         pts = zip(x, y)
+    else:
+        raise NotImplementedError(f"mode: {mode}")
 
     return Polygon(pts)
 
@@ -784,7 +786,7 @@ def shape_bbox_indexer(ds, poly):
     # Find indices nearest the rectangle' corners
     # Note that the nearest indices might be inside the shape, so we'll need to add a *halo* around those indices.
     if rectilinear:
-        if version.parse(xarray.__version__) < version.Version("2022.06.0"):
+        if version.parse(xarray.__version__) < version.Version("2022.6.0"):
             warnings.warn(
                 "CLISOPS will require xarray >= 2022.06 in the next major release. "
                 "Please update your environment dependencies.",
@@ -858,7 +860,7 @@ def create_weight_masks(
     >>> polys = gpd.read_file(path_to_multi_shape_file)  # doctest: +SKIP
     ...
     # Get a weight mask for each polygon in the shape file
-    >>> mask = create_weight_mask(x_dim=ds.lon, y_dim=ds.lat, poly=polys)  # doctest: +SKIP
+    >>> mask = create_weight_masks(x_dim=ds.lon, y_dim=ds.lat, poly=polys)  # doctest: +SKIP
     """
     try:
         from xesmf import SpatialAverager
@@ -924,7 +926,7 @@ def subset_shape(
     ds : Union[xarray.DataArray, xarray.Dataset]
         Input values.
     shape : Union[str, Path, gpd.GeoDataFrame]
-        Path to shape file, or directly a geodataframe. Supports formats compatible with geopandas.
+        Path to a shape file, or GeoDataFrame directly. Supports GeoPandas-compatible formats.
     raster_crs : Optional[Union[str, int]]
         EPSG number or PROJ4 string.
     shape_crs : Optional[Union[str, int]]
@@ -1672,8 +1674,8 @@ def subset_time_by_components(
 @check_start_end_levels
 def subset_level(
     da: Union[xarray.DataArray, xarray.Dataset],
-    first_level: Optional[Union[int, float]] = None,
-    last_level: Optional[Union[int, float]] = None,
+    first_level: Optional[Union[int, float, str]] = None,
+    last_level: Optional[Union[int, float, str]] = None,
 ) -> Union[xarray.DataArray, xarray.Dataset]:
     """Subset input DataArray or Dataset based on first and last levels.
 
@@ -1683,11 +1685,11 @@ def subset_level(
     ----------
     da : Union[xarray.DataArray, xarray.Dataset]
         Input data.
-    first_level : Optional[Union[int, float]]
+    first_level : Optional[Union[int, float, str]]
         First level of the subset (specified as the value, not the index).
         Can be either an integer or float.
         Defaults to first level of input data-array.
-    last_level : Optional[Union[int, float]]
+    last_level : Optional[Union[int, float, str]]
         Last level of the subset (specified as the value, not the index).
         Can be either an integer or float.
         Defaults to last level of input data-array.

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -35,6 +35,7 @@ __all__ = [
     "create_weight_masks",
     "distance",
     "subset_bbox",
+    "shape_bbox_indexer",
     "subset_gridpoint",
     "subset_shape",
     "subset_time",
@@ -230,8 +231,7 @@ def check_start_end_levels(func):
 def check_lons(func):
     @wraps(func)
     def func_checker(*args, **kwargs):
-        """
-        Reformat user-specified "lon" or "lon_bnds" values based on the lon dimensions of a supplied Dataset or DataArray.
+        """Reformat user-specified "lon" or "lon_bnds" values based on the lon dimensions of a supplied Dataset or DataArray.
 
         Examines an xarray object longitude dimensions and depending on extent (either -180 to +180 or 0 to +360),
         will reformat user-specified lon values to be synonymous with xarray object boundaries.
@@ -275,9 +275,7 @@ def check_lons(func):
 def check_levels_exist(func):
     @wraps(func)
     def func_checker(*args, **kwargs):
-        """
-        Check the requested levels exist in the input Dataset/DataArray.
-        If not: raise an Exception.
+        """Check the requested levels exist in the input Dataset/DataArray and, if not, raise an Exception.
 
         if the requested levels are not sorted in the order of the actual array then
         re-sort them to match the array in the input data.
@@ -313,11 +311,9 @@ def check_levels_exist(func):
 def check_datetimes_exist(func):
     @wraps(func)
     def func_checker(*args, **kwargs):
-        """
-        Check the requested datetimes exist in the input Dataset/DataArray.
-        If not: raise an Exception.
+        """Check the requested datetimes exist in the input Dataset/DataArray and, if not, raise an Exception.
 
-        if the requested datetimes are not sorted in the order of the actual array then
+        If the requested datetimes are not sorted in the order of the actual array then
         re-sort them to match the array in the input data.
 
         Modifies the "time_values" list in `kwargs` in place, if required.
@@ -356,8 +352,7 @@ def check_datetimes_exist(func):
 def convert_lat_lon_to_da(func):
     @wraps(func)
     def func_checker(*args, **kwargs):
-        """
-        Transform input lat, lon to DataArrays.
+        """Transform input lat, lon to DataArrays.
 
         Input can be int, float or any iterable.
         Expects a DataArray as first argument and checks is dim "site" already exists,
@@ -392,8 +387,7 @@ def convert_lat_lon_to_da(func):
 def wrap_lons_and_split_at_greenwich(func):
     @wraps(func)
     def func_checker(*args, **kwargs):
-        """
-        Split and reproject polygon vectors in a GeoDataFrame whose values cross the Greenwich Meridian.
+        """Split and reproject polygon vectors in a GeoDataFrame whose values cross the Greenwich Meridian.
 
         Begins by examining whether the geometry bounds the supplied cross longitude = 0 and if so, proceeds to split
         the polygons at the meridian into new polygons and erase a small buffer to prevent invalid geometries when
@@ -490,16 +484,16 @@ def create_mask(
     Parameters
     ----------
     x_dim : xarray.DataArray
-      X or longitudinal dimension of xarray object. Can also be given through `ds_in`.
+        X or longitudinal dimension of xarray object. Can also be given through `ds_in`.
     y_dim : xarray.DataArray
-      Y or latitudinal dimension of xarray object. Can also be given through `ds_in`.
+        Y or latitudinal dimension of xarray object. Can also be given through `ds_in`.
     poly : gpd.GeoDataFrame
-      GeoDataFrame used to create the xarray.DataArray mask. If its index doesn't have a
-      integer dtype, it will be reset to integers, which will be used in the mask.
+        GeoDataFrame used to create the xarray.DataArray mask. If its index doesn't have a
+        integer dtype, it will be reset to integers, which will be used in the mask.
     wrap_lons : bool
-      Shift vector longitudes by -180,180 degrees to 0,360 degrees; Default = False
-    check_overlap: bool
-      Perform a check to verify if shapes contain overlapping geometries.
+        Shift vector longitudes by -180,180 degrees to 0,360 degrees; Default = False
+    check_overlap : bool
+        Perform a check to verify if shapes contain overlapping geometries.
 
     Returns
     -------
@@ -507,22 +501,23 @@ def create_mask(
 
     Examples
     --------
-    >>> import geopandas as gpd  # doctest: +SKIP
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import create_mask  # doctest: +SKIP
-    >>> ds = xr.open_dataset(path_to_tasmin_file)  # doctest: +SKIP
-    >>> polys = gpd.read_file(path_to_multi_shape_file)  # doctest: +SKIP
-    ...
-    # Get a mask from all polygons in the shape file
-    >>> mask = create_mask(x_dim=ds.lon, y_dim=ds.lat, poly=polys)  # doctest: +SKIP
-    >>> ds = ds.assign_coords(regions=mask)  # doctest: +SKIP
-    ...
-    # Operations can be applied to each region with `groupby`. Ex:
-    >>> ds = ds.groupby('regions').mean()  # doctest: +SKIP
-    ...
-    # Extra step to retrieve the names of those polygons stored in another column (here "id")
-    >>> region_names = xr.DataArray(polys.id, dims=('regions',))  # doctest: +SKIP
-    >>> ds = ds.assign_coords(regions_names=region_names)  # doctest: +SKIP
+    .. code-block:: python
+
+        import geopandas as gpd
+        from clisops.core.subset import create_mask
+        ds = xr.open_dataset(path_to_tasmin_file)
+        polys = gpd.read_file(path_to_multi_shape_file)
+
+        # Get a mask from all polygons in the shape file
+        mask = create_mask(x_dim=ds.lon, y_dim=ds.lat, poly=polys)
+        ds = ds.assign_coords(regions=mask)
+
+        # Operations can be applied to each region with `groupby`. Ex:
+        ds = ds.groupby('regions').mean()
+
+        # Extra step to retrieve the names of those polygons stored in another column (here "id")
+        region_names = xr.DataArray(polys.id, dims=('regions',))
+        ds = ds.assign_coords(regions_names=region_names)
     """
     if check_overlap:
         _check_has_overlaps(polygons=poly)
@@ -589,12 +584,12 @@ def _rectilinear_grid_exterior_polygon(ds):
     Parameters
     ----------
     ds : xarray.Dataset
-      CF-compliant input dataset.
+        CF-compliant input dataset.
 
     Returns
     -------
     shapely.geometry.Polygon
-      Grid cell boundary.
+        Grid cell boundary.
     """
 
     # Add bounds if not present
@@ -635,16 +630,16 @@ def _curvilinear_grid_exterior_polygon(ds, mode="bbox"):
     Parameters
     ----------
     ds : xarray.Dataset
-      CF-compliant input dataset.
+        CF-compliant input dataset.
     mode : {bbox, cell_union}
-      Calculation mode. `bbox` takes the min and max longitude and latitude bounds and rounds them to 0.1 degree.
-      `cell_union` merges all grid cell polygons and finds the exterior. Also rounds and simplifies the coordinates
-      to smooth projection errors.
+        Calculation mode. `bbox` takes the min and max longitude and latitude bounds and rounds them to 0.1 degree.
+        `cell_union` merges all grid cell polygons and finds the exterior. Also rounds and simplifies the coordinates
+        to smooth projection errors.
 
     Returns
     -------
     shapely.geometry.Polygon
-      Grid cell boundary.
+        Grid cell boundary.
     """
     import math
 
@@ -709,18 +704,17 @@ def _curvilinear_grid_exterior_polygon(ds, mode="bbox"):
 def grid_exterior_polygon(ds):
     """Return a polygon tracing the grid's exterior.
 
-    This function is only accurate for a geographic lat/lon projection.
-    For projected grids, it's a rough approximation.
+    This function is only accurate for a geographic lat/lon projection. For projected grids, it's a rough approximation.
 
     Parameters
     ----------
     ds : xarray.Dataset
-      CF-compliant input dataset.
+        CF-compliant input dataset.
 
     Returns
     -------
     shapely.geometry.Polygon
-      Grid cell boundary.
+        Grid cell boundary.
 
     Notes
     -----
@@ -742,20 +736,19 @@ def is_rectilinear(ds):
 
 
 def shape_bbox_indexer(ds, poly):
-    """
-    Return a spatial indexer that selects the indices of the grid cells covering the given geometries.
+    """Return a spatial indexer that selects the indices of the grid cells covering the given geometries.
 
     Parameters
     ----------
     ds : xr.Dataset
-      Input dataset.
+        Input dataset.
     poly : gpd.GeoDataFrame
-      Shapes to cover.
+        Shapes to cover.
 
     Returns
     -------
     dict
-      xarray indexer along native dataset coordinates, to be used as an argument to `isel`.
+        xarray indexer along native dataset coordinates, to be used as an argument to `isel`.
 
     Examples
     --------
@@ -843,12 +836,12 @@ def create_weight_masks(
     Parameters
     ----------
     ds_in : Union[xarray.DataArray, xarray.Dataset]
-      xarray object containing the grid information, as understood by xESMF.
-      For 2D lat/lon coordinates, the bounds arrays are required,
+        xarray object containing the grid information, as understood by xESMF.
+        For 2D lat/lon coordinates, the bounds arrays are required,
     poly : gpd.GeoDataFrame
-      GeoDataFrame used to create the xarray.DataArray mask.
-      One mask will be created for each row in the dataframe.
-      Will be converted to EPSG:4326 if needed.
+        GeoDataFrame used to create the xarray.DataArray mask.
+        One mask will be created for each row in the dataframe.
+        Will be converted to EPSG:4326 if needed.
 
     Returns
     -------
@@ -929,36 +922,37 @@ def subset_shape(
     Parameters
     ----------
     ds : Union[xarray.DataArray, xarray.Dataset]
-      Input values.
+        Input values.
     shape : Union[str, Path, gpd.GeoDataFrame]
-      Path to shape file, or directly a geodataframe. Supports formats compatible with geopandas.
+        Path to shape file, or directly a geodataframe. Supports formats compatible with geopandas.
     raster_crs : Optional[Union[str, int]]
-      EPSG number or PROJ4 string.
+        EPSG number or PROJ4 string.
     shape_crs : Optional[Union[str, int]]
-      EPSG number or PROJ4 string.
+        EPSG number or PROJ4 string.
     buffer : Optional[Union[int, float]]
-      Buffer the shape in order to select a larger region stemming from it. Units are based on the shape degrees/metres.
+        Buffer the shape in order to select a larger region stemming from it.
+        Units are based on the shape degrees/metres.
     start_date : Optional[str]
-      Start date of the subset.
-      Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
-      Defaults to first day of input data-array.
+        Start date of the subset.
+        Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
+        Defaults to first day of input data-array.
     end_date : Optional[str]
-      End date of the subset.
-      Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
-      Defaults to last day of input data-array.
+        End date of the subset.
+        Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
+        Defaults to last day of input data-array.
     first_level : Optional[Union[int, float]]
-      First level of the subset.
-      Can be either an integer or float.
-      Defaults to first level of input data-array.
+        First level of the subset.
+        Can be either an integer or float.
+        Defaults to first level of input data-array.
     last_level : Optional[Union[int, float]]
-      Last level of the subset.
-      Can be either an integer or float.
-      Defaults to last level of input data-array.
+        Last level of the subset.
+        Can be either an integer or float.
+        Defaults to last level of input data-array.
 
     Returns
     -------
     Union[xarray.DataArray, xarray.Dataset]
-      A subset of `ds`
+        A subset of `ds`
 
     Notes
     -----
@@ -968,19 +962,21 @@ def subset_shape(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import subset_shape  # doctest: +SKIP
-    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-    ...
-    # Subset data array by shape
-    >>> prSub = subset_shape(pr, shape=path_to_shape_file)  # doctest: +SKIP
-    ...
-    # Subset data array by shape and single year
-    >>> prSub = subset_shape(pr, shape=path_to_shape_file, start_date='1990-01-01', end_date='1990-12-31')  # doctest: +SKIP
-    ...
-    # Subset multiple variables in a single dataset
-    >>> ds = xr.open_mfdataset([path_to_tasmin_file, path_to_tasmax_file])  # doctest: +SKIP
-    >>> dsSub = subset_shape(ds, shape=path_to_shape_file)  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr
+        from clisops.core.subset import subset_shape
+        pr = xr.open_dataset(path_to_pr_file).pr
+
+        # Subset data array by shape
+        prSub = subset_shape(pr, shape=path_to_shape_file)
+
+        # Subset data array by shape and single year
+        prSub = subset_shape(pr, shape=path_to_shape_file, start_date='1990-01-01', end_date='1990-12-31')
+
+        # Subset multiple variables in a single dataset
+        ds = xr.open_mfdataset([path_to_tasmin_file, path_to_tasmax_file])
+        dsSub = subset_shape(ds, shape=path_to_shape_file)
     """
     wgs84 = CRS(4326)
     # PROJ4 definition for WGS84 with longitudes ranged between -180/+180.
@@ -1006,8 +1002,8 @@ def subset_shape(
     lon_bnds = (minx, maxx)
     lat_bnds = (miny, maxy)
 
-    # If polygon doesn't cross prime meridian, subset bbox first to reduce processing time
-    # Only case not implemented is when lon_bnds cross the 0 deg meridian but dataset grid has all positive lons
+    # If polygon doesn't cross prime meridian, subset bbox first to reduce processing time.
+    # Only case not implemented is when lon_bnds cross the 0 deg meridian but dataset grid has all positive lons.
     try:
         ds_copy = subset_bbox(ds_copy, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
     except ValueError as e:
@@ -1084,7 +1080,7 @@ def subset_shape(
     sp_dims = set(mask_2d.dims)  # Spatial dimensions
 
     # Find the outer mask. When subsetting unconnected shapes,
-    # we dont want to drop the inner NaN regions, it may cause problems downstream.
+    # we don't want to drop the inner NaN regions, it may cause problems downstream.
     inner_mask = xarray.full_like(mask_2d, True, dtype=bool)
     for dim in sp_dims:
         # For each dimension, propagate shape indexes in either directions
@@ -1149,51 +1145,54 @@ def subset_bbox(
     Parameters
     ----------
     da : Union[xarray.DataArray, xarray.Dataset]
-      Input data.
+        Input data.
     lon_bnds : Union[np.array, Tuple[Optional[float], Optional[float]]]
-      List of minimum and maximum longitudinal bounds. Optional. Defaults to all longitudes in original data-array.
+        List of minimum and maximum longitudinal bounds. Optional. Defaults to all longitudes in original data-array.
     lat_bnds : Union[np.array, Tuple[Optional[float], Optional[float]]]
-      List of minimum and maximum latitudinal bounds. Optional. Defaults to all latitudes in original data-array.
+        List of minimum and maximum latitudinal bounds. Optional. Defaults to all latitudes in original data-array.
     start_date : Optional[str]
-      Start date of the subset.
-      Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
-      Defaults to first day of input data-array.
+        Start date of the subset.
+        Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
+        Defaults to first day of input data-array.
     end_date : Optional[str]
-      End date of the subset.
-      Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
-      Defaults to last day of input data-array.
+        End date of the subset.
+        Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
+        Defaults to last day of input data-array.
     first_level : Optional[Union[int, float]]
-      First level of the subset.
-      Can be either an integer or float.
-      Defaults to first level of input data-array.
+        First level of the subset.
+        Can be either an integer or float.
+        Defaults to first level of input data-array.
     last_level : Optional[Union[int, float]]
-      Last level of the subset.
-      Can be either an integer or float.
-      Defaults to last level of input data-array.
+        Last level of the subset.
+        Can be either an integer or float.
+        Defaults to last level of input data-array.
     time_values: Optional[Sequence[str]]
-      A list of datetime strings to subset.
+        A list of datetime strings to subset.
     level_values: Optional[Union[Sequence[float], Sequence[int]]]
-      A list of level values to select.
+        A list of level values to select.
 
     Returns
     -------
     Union[xarray.DataArray, xarray.Dataset]
-      Subsetted xarray.DataArray or xarray.Dataset
+        Subsetted xarray.DataArray or xarray.Dataset
 
-    Note
-    ----
-        subset_bbox expects the lower and upper bounds to be provided in ascending order.
-        If the actual coordinate values are descending then this will be detected
-        and your selection reversed before the data subset is returned.
+    Notes
+    -----
+    subset_bbox expects the lower and upper bounds to be provided in ascending order.
+    If the actual coordinate values are descending then this will be detected
+    and your selection reversed before the data subset is returned.
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import subset_bbox  # doctest: +SKIP
-    >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
-    ...
-    # Subset lat lon
-    >>> prSub = subset_bbox(ds.pr, lon_bnds=[-75, -70], lat_bnds=[40, 45])  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr
+        from clisops.core.subset import subset_bbox
+
+        ds = xr.open_dataset(path_to_pr_file)
+
+        # Subset lat lon
+        prSub = subset_bbox(ds.pr, lon_bnds=[-75, -70], lat_bnds=[40, 45])
     """
     lat = get_lat(da).name
     lon = get_lon(da).name
@@ -1311,14 +1310,14 @@ def assign_bounds(
     Parameters
     ----------
     bounds : Tuple[Optional[float], Optional[float]]
-      Boundaries.
+        Boundaries.
     coord : xarray.Coordinate
-      Grid coordinates.
+        Grid coordinates.
 
     Returns
     -------
     tuple
-      Lower and upper grid boundaries.
+        Lower and upper grid boundaries.
 
     """
     if bounds[0] > bounds[1]:
@@ -1410,48 +1409,51 @@ def subset_gridpoint(
     Parameters
     ----------
     da : Union[xarray.DataArray, xarray.Dataset]
-      Input data.
+        Input data.
     lon : Optional[Union[float, Sequence[float], xarray.DataArray]]
-      Longitude coordinate(s). Must be of the same length as lat.
+        Longitude coordinate(s). Must be of the same length as lat.
     lat : Optional[Union[float, Sequence[float], xarray.DataArray]]
-      Latitude coordinate(s). Must be of the same length as lon.
+        Latitude coordinate(s). Must be of the same length as lon.
     start_date : Optional[str]
-      Start date of the subset.
-      Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
-      Defaults to first day of input data-array.
+        Start date of the subset.
+        Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
+        Defaults to first day of input data-array.
     end_date : Optional[str]
-      End date of the subset.
-      Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
-      Defaults to last day of input data-array.
+        End date of the subset.
+        Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
+        Defaults to last day of input data-array.
     first_level : Optional[Union[int, float]]
-      First level of the subset.
-      Can be either an integer or float.
-      Defaults to first level of input data-array.
+        First level of the subset.
+        Can be either an integer or float.
+        Defaults to first level of input data-array.
     last_level : Optional[Union[int, float]]
-      Last level of the subset.
-      Can be either an integer or float.
-      Defaults to last level of input data-array.
+        Last level of the subset.
+        Can be either an integer or float.
+        Defaults to last level of input data-array.
     tolerance : Optional[float]
-      Masks values if the distance to the nearest gridpoint is larger than tolerance in meters.
+        Masks values if the distance to the nearest gridpoint is larger than tolerance in meters.
     add_distance: bool
 
     Returns
     -------
     Union[xarray.DataArray, xarray.Dataset]
-      Subsetted xarray.DataArray or xarray.Dataset
+         Subsetted xarray.DataArray or xarray.Dataset
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import subset_gridpoint  # doctest: +SKIP
-    >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
-    ...
-    # Subset lat lon point
-    >>> prSub = subset_gridpoint(ds.pr, lon=-75,lat=45)  # doctest: +SKIP
-    ...
-    # Subset multiple variables in a single dataset
-    >>> ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])  # doctest: +SKIP
-    >>> dsSub = subset_gridpoint(ds, lon=-75, lat=45)  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr
+        from clisops.core.subset import subset_gridpoint
+
+        ds = xr.open_dataset(path_to_pr_file)
+
+        # Subset lat lon point
+        prSub = subset_gridpoint(ds.pr, lon=-75,lat=45)
+
+        # Subset multiple variables in a single dataset
+        ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])
+        dsSub = subset_gridpoint(ds, lon=-75, lat=45)
     """
     if lat is None or lon is None:
         raise ValueError("Insufficient coordinates provided to locate grid point(s).")
@@ -1524,47 +1526,51 @@ def subset_time(
     end_date: Optional[str] = None,
 ) -> Union[xarray.DataArray, xarray.Dataset]:
     """Subset input DataArray or Dataset based on start and end years.
+
     Return a subset of a DataArray or Dataset for dates falling within the provided bounds.
 
     Parameters
     ----------
     da : Union[xarray.DataArray, xarray.Dataset]
-      Input data.
+        Input data.
     start_date : Optional[str]
-      Start date of the subset.
-      Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
-      Defaults to first day of input data-array.
+        Start date of the subset.
+        Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
+        Defaults to first day of input data-array.
     end_date : Optional[str]
-      End date of the subset.
-      Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
-      Defaults to last day of input data-array.
+        End date of the subset.
+        Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
+        Defaults to last day of input data-array.
 
     Returns
     -------
     Union[xarray.DataArray, xarray.Dataset]
-      Subsetted xarray.DataArray or xarray.Dataset
+        Subsetted xarray.DataArray or xarray.Dataset
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import subset_time  # doctest: +SKIP
-    >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
-    ...
-    # Subset complete years
-    >>> prSub = subset_time(ds.pr,start_date='1990',end_date='1999')  # doctest: +SKIP
-    ...
-    # Subset single complete year
-    >>> prSub = subset_time(ds.pr,start_date='1990',end_date='1990')  # doctest: +SKIP
-    ...
-    # Subset multiple variables in a single dataset
-    >>> ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])  # doctest: +SKIP
-    >>> dsSub = subset_time(ds,start_date='1990',end_date='1999')  # doctest: +SKIP
-    ...
-    # Subset with year-month precision - Example subset 1990-03-01 to 1999-08-31 inclusively
-    >>> txSub = subset_time(ds.tasmax,start_date='1990-03',end_date='1999-08')  # doctest: +SKIP
-    ...
-    # Subset with specific start_dates and end_dates
-    >>> tnSub = subset_time(ds.tasmin,start_date='1990-03-13',end_date='1990-08-17')  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr
+        from clisops.core.subset import subset_time
+
+        ds = xr.open_dataset(path_to_pr_file)
+
+        # Subset complete years
+        prSub = subset_time(ds.pr,start_date='1990',end_date='1999')
+
+        # Subset single complete year
+        prSub = subset_time(ds.pr,start_date='1990',end_date='1990')
+
+        # Subset multiple variables in a single dataset
+        ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])
+        dsSub = subset_time(ds,start_date='1990',end_date='1999')
+
+        # Subset with year-month precision - Example subset 1990-03-01 to 1999-08-31 inclusively
+        txSub = subset_time(ds.tasmax,start_date='1990-03',end_date='1999-08')
+
+        # Subset with specific start_dates and end_dates
+        tnSub = subset_time(ds.tasmin,start_date='1990-03-13',end_date='1990-08-17')
 
     Notes
     -----
@@ -1579,28 +1585,33 @@ def subset_time_by_values(
     time_values: Optional[Sequence[str]] = None,
 ) -> Union[xarray.DataArray, xarray.Dataset]:
     """Subset input DataArray or Dataset based on a sequence of datetime strings.
+
     Return a subset of a DataArray or Dataset for datetimes matching those requested.
 
     Parameters
     ----------
     da : Union[xarray.DataArray, xarray.Dataset]
-      Input data.
-    time_values: Optional[Sequence[str]] = None
+        Input data.
+    time_values: Optional[Sequence[str]]
+        Values for time. Default: ``None``
 
     Returns
     -------
     Union[xarray.DataArray, xarray.Dataset]
-      Subsetted xarray.DataArray or xarray.Dataset
+        Subsetted xarray.DataArray or xarray.Dataset
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import subset_time_by_values  # doctest: +SKIP
-    >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
-    ...
-    # Subset a selection of datetimes
-    >>> times = ["2015-01-01", "2018-12-05", "2021-06-06"]
-    >>> prSub = subset_time_by_values(ds.pr, time_values=times)  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr
+        from clisops.core.subset import subset_time_by_values
+
+        ds = xr.open_dataset(path_to_pr_file)
+
+        # Subset a selection of datetimes
+        times = ["2015-01-01", "2018-12-05", "2021-06-06"]
+        prSub = subset_time_by_values(ds.pr, time_values=times)
 
     Notes
     -----
@@ -1615,7 +1626,7 @@ def subset_time_by_components(
     da: Union[xarray.DataArray, xarray.Dataset],
     *,
     time_components: Union[Dict, None] = None,
-):
+) -> xarray.DataArray:
     """Subsets by one or more time components (year, month, day etc).
 
     Parameters
@@ -1630,13 +1641,15 @@ def subset_time_by_components(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import subset_time_by_components  # doctest: +SKIP
-    ...
-    To select all Winter months (Dec, Jan, Feb) or [12, 1, 2]:
-    >>> da = xr.open_dataset(path_to_file).pr  # doctest: +SKIP
-    >>> winter_dict = {"month": [12, 1, 2]}
-    >>> res = subset_time_by_components(da, time_components=winter_dict)  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr
+        from clisops.core.subset import subset_time_by_components
+
+        # To select all Winter months (Dec, Jan, Feb) or [12, 1, 2]:
+        da = xr.open_dataset(path_to_file).pr
+        winter_dict = {"month": [12, 1, 2]}
+        res = subset_time_by_components(da, time_components=winter_dict)
     """
     # Create a set of indices that match the requested time components
     req_indices = set(range(len(da.time.values)))
@@ -1663,41 +1676,45 @@ def subset_level(
     last_level: Optional[Union[int, float]] = None,
 ) -> Union[xarray.DataArray, xarray.Dataset]:
     """Subset input DataArray or Dataset based on first and last levels.
+
     Return a subset of a DataArray or Dataset for levels falling within the provided bounds.
 
     Parameters
     ----------
     da : Union[xarray.DataArray, xarray.Dataset]
-      Input data.
+        Input data.
     first_level : Optional[Union[int, float]]
-      First level of the subset (specified as the value, not the index).
-      Can be either an integer or float.
-      Defaults to first level of input data-array.
+        First level of the subset (specified as the value, not the index).
+        Can be either an integer or float.
+        Defaults to first level of input data-array.
     last_level : Optional[Union[int, float]]
-      Last level of the subset (specified as the value, not the index).
-      Can be either an integer or float.
-      Defaults to last level of input data-array.
+        Last level of the subset (specified as the value, not the index).
+        Can be either an integer or float.
+        Defaults to last level of input data-array.
 
     Returns
     -------
     Union[xarray.DataArray, xarray.Dataset]
-      Subsetted xarray.DataArray or xarray.Dataset
+        Subsetted xarray.DataArray or xarray.Dataset
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import subset_level  # doctest: +SKIP
-    >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
-    ...
-    # Subset complete levels
-    >>> prSub = subset_level(ds.pr,first_level=0,last_level=30)  # doctest: +SKIP
-    ...
-    # Subset single level
-    >>> prSub = subset_level(ds.pr,first_level=1000,last_level=1000)  # doctest: +SKIP
-    ...
-    # Subset multiple variables in a single dataset
-    >>> ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])  # doctest: +SKIP
-    >>> dsSub = subset_time(ds,first_level=1000.0,last_level=850.0)  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr
+        from clisops.core.subset import subset_level
+
+        ds = xr.open_dataset(path_to_pr_file)
+
+        # Subset complete levels
+        prSub = subset_level(ds.pr,first_level=0,last_level=30)
+
+        # Subset single level
+        prSub = subset_level(ds.pr,first_level=1000,last_level=1000)
+
+        # Subset multiple variables in a single dataset
+        ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])
+        dsSub = subset_time(ds,first_level=1000.0,last_level=850.0)
 
     Notes
     -----
@@ -1720,29 +1737,33 @@ def subset_level_by_values(
     level_values: Optional[Union[Sequence[float], Sequence[int]]] = None,
 ) -> Union[xarray.DataArray, xarray.Dataset]:
     """Subset input DataArray or Dataset based on a sequence of vertical level values.
+
     Return a subset of a DataArray or Dataset for levels matching those requested.
 
     Parameters
     ----------
     da : Union[xarray.DataArray, xarray.Dataset]
-      Input data.
-    level_values: Optional[Union[Sequence[float], Sequence[int]]]
-      A list of level values to select.
+        Input data.
+    level_values : Optional[Union[Sequence[float], Sequence[int]]]
+        A list of level values to select.
 
     Returns
     -------
     Union[xarray.DataArray, xarray.Dataset]
-      Subsetted xarray.DataArray or xarray.Dataset
+        Subsetted xarray.DataArray or xarray.Dataset
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import subset_level_by_values  # doctest: +SKIP
-    >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
-    ...
-    # Subset a selection of levels
-    >>> levels = [1000., 850., 250., 100.]
-    >>> prSub = subset_level_by_values(ds.pr, level_values=levels)  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr
+        from clisops.core.subset import subset_level_by_values
+
+        ds = xr.open_dataset(path_to_pr_file)
+
+        # Subset a selection of levels
+        levels = [1000., 850., 250., 100.]
+        prSub = subset_level_by_values(ds.pr, level_values=levels)
 
     Notes
     -----
@@ -1766,27 +1787,29 @@ def distance(
     Parameters
     ----------
     da : Union[xarray.DataArray, xarray.Dataset]
-      Input data.
+        Input data.
     lon : Union[float, Sequence[float], xarray.DataArray]
-      Longitude coordinate.
+        Longitude coordinate.
     lat : Union[float, Sequence[float], xarray.DataArray]
-      Latitude coordinate.
+        Latitude coordinate.
 
     Returns
     -------
     xarray.DataArray
-      Distance in meters to point.
+        Distance in meters to point.
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from clisops.core.subset import distance  # doctest: +SKIP
-    ...
-    To get the indices from closest point, use:
-    >>> da = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-    >>> d = distance(da, lon=-75, lat=45)  # doctest: +SKIP
-    >>> k = d.argmin()  # doctest: +SKIP
-    >>> i, j, _ = np.unravel_index(k, d.shape)  # doctest: +SKIP
+    .. code-block:: python
+
+        import xarray as xr
+        from clisops.core.subset import distance
+
+        # To get the indices from the closest point, use:
+        da = xr.open_dataset(path_to_pr_file).pr
+        d = distance(da, lon=-75, lat=45)
+        k = d.argmin()
+        i, j, _ = np.unravel_index(k, d.shape)
     """
     ptdim = lat.dims[0]
 

--- a/clisops/ops/average.py
+++ b/clisops/ops/average.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, Sequence
 
 import xarray as xr
 from roocs_utils.exceptions import InvalidParameterValue
@@ -43,8 +43,8 @@ class Average(Operation):
 
 
 def average_over_dims(
-    ds,
-    dims: Optional[Union[Tuple[str], DimensionParameter]] = None,
+    ds: Union[xr.Dataset, str],
+    dims: Optional[Union[Sequence[str], DimensionParameter]] = None,
     ignore_undetected_dims: bool = False,
     output_dir: Optional[Union[str, Path]] = None,
     output_type="netcdf",
@@ -57,7 +57,7 @@ def average_over_dims(
     ----------
     ds : Union[xr.Dataset, str]
         Xarray dataset.
-    dims : Optional[Union[Tuple[{"time", "level", "latitude", "longitude"}], DimensionParameter]]
+    dims : Optional[Union[Sequence[{"time", "level", "latitude", "longitude"}], DimensionParameter]]
         The dimensions over which to apply the average. If None, none of the dimensions are averaged over. Dimensions
         must be one of ["time", "level", "latitude", "longitude"].
     ignore_undetected_dims : bool
@@ -139,7 +139,7 @@ def average_time(
     output_dir : Optional[Union[str, Path]]
     output_type : {"netcdf", "nc", "zarr", "xarray"}
     split_method : {"time:auto"}
-    file_name r: {"standard", "simple"}
+    file_namer: {"standard", "simple"}
 
     Returns
     -------

--- a/clisops/ops/average.py
+++ b/clisops/ops/average.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Tuple, Union, Sequence
+from typing import List, Optional, Sequence, Tuple, Union
 
 import xarray as xr
 from roocs_utils.exceptions import InvalidParameterValue

--- a/clisops/ops/average.py
+++ b/clisops/ops/average.py
@@ -10,8 +10,6 @@ from clisops.core import average
 from clisops.ops.base_operation import Operation
 from clisops.utils.file_namers import get_file_namer
 
-# from clisops.utils.output_utils import get_output, get_time_slices
-
 __all__ = ["average_over_dims", "average_time"]
 
 
@@ -57,14 +55,15 @@ def average_over_dims(
 
     Parameters
     ----------
-    ds: Union[xr.Dataset, str]
-    dims : Optional[Union[Tuple[str], DimensionParameter]]
-      The dimensions over which to apply the average. If None, none of the dimensions are averaged over. Dimensions
-      must be one of ["time", "level", "latitude", "longitude"].
-    ignore_undetected_dims: bool
-      If the dimensions specified are not found in the dataset, an Exception will be raised if set to True.
-      If False, an exception will not be raised and the other dimensions will be averaged over. Default = False
-    output_dir: Optional[Union[str, Path]] = None
+    ds : Union[xr.Dataset, str]
+        Xarray dataset.
+    dims : Optional[Union[Tuple[{"time", "level", "latitude", "longitude"}], DimensionParameter]]
+        The dimensions over which to apply the average. If None, none of the dimensions are averaged over. Dimensions
+        must be one of ["time", "level", "latitude", "longitude"].
+    ignore_undetected_dims : bool
+        If the dimensions specified are not found in the dataset, an Exception will be raised if set to True.
+        If False, an exception will not be raised and the other dimensions will be averaged over. Default = False
+    output_dir: Optional[Union[str, Path]]
     output_type: {"netcdf", "nc", "zarr", "xarray"}
     split_method: {"time:auto"}
     file_namer: {"standard", "simple"}
@@ -133,13 +132,14 @@ def average_time(
 
     Parameters
     ----------
-    ds: Union[xr.Dataset, str]
-    freq: str
-      The frequency to average over. One of "month", "year".
-    output_dir: Optional[Union[str, Path]] = None
-    output_type: {"netcdf", "nc", "zarr", "xarray"}
-    split_method: {"time:auto"}
-    file_namer: {"standard", "simple"}
+    ds : Union[xr.Dataset, str]
+        Xarray dataset.
+    freq : str
+        The frequency to average over. One of "month", "year".
+    output_dir : Optional[Union[str, Path]]
+    output_type : {"netcdf", "nc", "zarr", "xarray"}
+    split_method : {"time:auto"}
+    file_name r: {"standard", "simple"}
 
     Returns
     -------

--- a/clisops/ops/base_operation.py
+++ b/clisops/ops/base_operation.py
@@ -61,10 +61,7 @@ class Operation:
         return namer
 
     def _calculate(self):
-        """
-        The `_calculate()` method is implemented within each operation
-        sub-class.
-        """
+        """The `_calculate()` method is implemented within each operation subclass."""
         raise NotImplementedError
 
     def _remove_redundant_fill_values(self, ds):
@@ -113,12 +110,12 @@ class Operation:
 
     def process(self):
         """
-        Main processing method used by all sub-classes.
+        Main processing method used by all subclasses.
 
-        Returns a list of outputs, which might be:
-        - netCDF file paths
-        - Zarr file paths
-        - xarray Datasets
+        Returns
+        -------
+        List[Union[xarray.Dataset, os.PathLike]]
+            A list of outputs, which might be NetCDF file paths, Zarr file paths, or xarray.Dataset
         """
         # Create an empty list for outputs
         outputs = list()
@@ -143,7 +140,7 @@ class Operation:
         # Loop through each time slice
         for tslice in time_slices:
 
-            # If there is only one time slice and it is None:
+            # If there is only one time slice, and it is None:
             # - then just set the result Dataset to the processed Dataset
             if tslice is None:
                 result_ds = processed_ds

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -6,9 +6,9 @@ from loguru import logger
 from roocs_utils.parameter import parameterise
 from roocs_utils.parameter.area_parameter import AreaParameter
 from roocs_utils.parameter.level_parameter import LevelParameter
+from roocs_utils.parameter.param_utils import Interval, Series
 from roocs_utils.parameter.time_components_parameter import TimeComponentsParameter
 from roocs_utils.parameter.time_parameter import TimeParameter
-from roocs_utils.parameter.param_utils import Interval, Series
 
 from clisops.core import (
     subset_bbox,
@@ -178,7 +178,10 @@ def subset(
     ] = None,
     level: Optional[
         Union[
-            str, Tuple[Union[int, float, str], Union[int, float, str]], LevelParameter, Interval
+            str,
+            Tuple[Union[int, float, str], Union[int, float, str]],
+            LevelParameter,
+            Interval,
         ]
     ] = None,
     time_components: Optional[Union[str, Dict, TimeComponentsParameter]] = None,

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -19,17 +19,14 @@ from clisops.core import (
 )
 from clisops.core.subset import assign_bounds, get_lat, get_lon  # noqa
 from clisops.ops.base_operation import Operation
-from clisops.utils.common import expand_wildcards
 from clisops.utils.dataset_utils import cf_convert_between_lon_frames
-from clisops.utils.file_namers import get_file_namer
-from clisops.utils.output_utils import get_output, get_time_slices
 
 __all__ = ["Subset", "subset"]
 
 
 class Subset(Operation):
     def _resolve_params(self, **params):
-        """Generates a dictionary of subset parameters"""
+        """Generates a dictionary of subset parameters."""
         time = params.get("time", None)
         area = params.get("area", None)
         level = params.get("level", None)
@@ -193,15 +190,15 @@ def subset(
 
     Parameters
     ----------
-    ds: Union[xr.Dataset, str]
-    time: Optional[Union[str, Tuple[str, str], TimeParameter]] = None,
-    area: str or AreaParameter or Tuple[Union[int, float, str], Union[int, float, str], Union[int, float, str], Union[int, float, str]], optional
-    level: Optional[Union[str, Tuple[Union[int, float, str], Union[int, float, str]], LevelParameter] = None,
-    time_components: Optional[Union[str, Dict, TimeComponentsParameter]] = None,
-    output_dir: Optional[Union[str, Path]] = None
-    output_type: {"netcdf", "nc", "zarr", "xarray"}
-    split_method: {"time:auto"}
-    file_namer: {"standard", "simple"}
+    ds : Union[xr.Dataset, str]
+    time : Optional[Union[str, Tuple[str, str], TimeParameter]] = None,
+    area : str or AreaParameter or Tuple[Union[int, float, str], Union[int, float, str], Union[int, float, str], Union[int, float, str]], optional
+    level : Optional[Union[str, Tuple[Union[int, float, str], Union[int, float, str]], LevelParameter] = None,
+    time_components : Optional[Union[str, Dict, TimeComponentsParameter]] = None,
+    output_dir : Optional[Union[str, Path]] = None
+    output_type : {"netcdf", "nc", "zarr", "xarray"}
+    split_method : {"time:auto"}
+    file_namer : {"standard", "simple"}
 
     Returns
     -------
@@ -215,8 +212,7 @@ def subset(
     | time: ("1999-01-01T00:00:00", "2100-12-30T00:00:00") or "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z"
     | area: (-5.,49.,10.,65) or "0.,49.,10.,65" or [0, 49.5, 10, 65]
     | level: (1000.,) or "1000/2000" or ("1000.50", "2000.60")
-    | time_components: "year:2000,2004,2008|month:01,02" or {"year": (2000, 2004, 2008),
-    |                                                        "months": (1, 2)}
+    | time_components: "year:2000,2004,2008|month:01,02" or {"year": (2000, 2004, 2008), "months": (1, 2)}
     | output_dir: "/cache/wps/procs/req0111"
     | output_type: "netcdf"
     | split_method: "time:auto"

--- a/clisops/ops/subset.py
+++ b/clisops/ops/subset.py
@@ -8,6 +8,7 @@ from roocs_utils.parameter.area_parameter import AreaParameter
 from roocs_utils.parameter.level_parameter import LevelParameter
 from roocs_utils.parameter.time_components_parameter import TimeComponentsParameter
 from roocs_utils.parameter.time_parameter import TimeParameter
+from roocs_utils.parameter.param_utils import Interval, Series
 
 from clisops.core import (
     subset_bbox,
@@ -162,7 +163,7 @@ class Subset(Operation):
 def subset(
     ds: Union[xr.Dataset, str, Path],
     *,
-    time: Optional[Union[str, Tuple[str, str], TimeParameter]] = None,
+    time: Optional[Union[str, Tuple[str, str], TimeParameter, Series, Interval]] = None,
     area: Optional[
         Union[
             str,
@@ -177,7 +178,7 @@ def subset(
     ] = None,
     level: Optional[
         Union[
-            str, Tuple[Union[int, float, str], Union[int, float, str]], LevelParameter
+            str, Tuple[Union[int, float, str], Union[int, float, str]], LevelParameter, Interval
         ]
     ] = None,
     time_components: Optional[Union[str, Dict, TimeComponentsParameter]] = None,
@@ -191,9 +192,9 @@ def subset(
     Parameters
     ----------
     ds : Union[xr.Dataset, str]
-    time : Optional[Union[str, Tuple[str, str], TimeParameter]] = None,
+    time : Optional[Union[str, Tuple[str, str], TimeParameter, Series, Interval]] = None,
     area : str or AreaParameter or Tuple[Union[int, float, str], Union[int, float, str], Union[int, float, str], Union[int, float, str]], optional
-    level : Optional[Union[str, Tuple[Union[int, float, str], Union[int, float, str]], LevelParameter] = None,
+    level : Optional[Union[str, Tuple[Union[int, float, str], Union[int, float, str]], LevelParameter, Interval] = None,
     time_components : Optional[Union[str, Dict, TimeComponentsParameter]] = None,
     output_dir : Optional[Union[str, Path]] = None
     output_type : {"netcdf", "nc", "zarr", "xarray"}

--- a/clisops/utils/common.py
+++ b/clisops/utils/common.py
@@ -13,7 +13,7 @@ def expand_wildcards(paths: Union[str, Path]) -> list:
 
 
 def _logging_examples() -> None:
-    """Testing module,"""
+    """Testing module."""
     logger.trace("0")
     logger.debug("1")
     logger.info("2")

--- a/clisops/utils/common.py
+++ b/clisops/utils/common.py
@@ -13,7 +13,7 @@ def expand_wildcards(paths: Union[str, Path]) -> list:
 
 
 def _logging_examples() -> None:
-    """Testing module"""
+    """Testing module,"""
     logger.trace("0")
     logger.debug("1")
     logger.info("2")

--- a/clisops/utils/dataset_utils.py
+++ b/clisops/utils/dataset_utils.py
@@ -1,8 +1,7 @@
-import math
 import warnings
 from typing import Optional
 
-import cf_xarray as cfxr
+import cf_xarray  # noqa
 import cftime
 import numpy as np
 import xarray as xr
@@ -259,9 +258,9 @@ def cf_convert_between_lon_frames(ds_in, lon_interval):
 
 
 def check_lon_alignment(ds, lon_bnds):
-    """
-    Check whether the longitude subset requested is within the bounds of the dataset. If not try to roll the dataset so
-    that the request is. Raise an exception if rolling is not possible.
+    """Check whether the longitude subset requested is within the bounds of the dataset.
+
+    If not try to roll the dataset so that the request is. Raise an exception if rolling is not possible.
     """
     low, high = lon_bnds
     lon = get_coord_by_type(ds, "longitude", ignore_aux_coords=False)
@@ -321,11 +320,11 @@ def adjust_date_to_calendar(da, date, direction="backwards"):
 
     Parameters
     ----------
-    da: xarray.Dataset or xarray.DataArray
+    da : xarray.Dataset or xarray.DataArray
         The data to examine.
-    date: str
+    date : str
         The date to check.
-    direction: str
+    direction : str
         The direction to move in days to find a date that does exist.
         'backwards' means the search will go backwards in time until an existing date is found.
         'forwards' means the search will go forwards in time.
@@ -410,7 +409,7 @@ def detect_bounds(ds, coordinate) -> Optional[str]:
 
     Parameters
     ----------
-    ds: xarray.Dataset, xarray.DataArray
+    ds : xarray.Dataset, xarray.DataArray
         Dataset the coordinate bounds variable name shall be obtained from.
     coordinate : str
         Name of the coordinate variable to determine the bounds from.

--- a/clisops/utils/file_namers.py
+++ b/clisops/utils/file_namers.py
@@ -6,14 +6,14 @@ from clisops.utils.output_utils import get_format_extension
 
 
 def get_file_namer(name):
-    """Returns the correct filenamer from the provided name"""
+    """Returns the correct filenamer from the provided name."""
     namers = {"standard": StandardFileNamer, "simple": SimpleFileNamer}
 
     return namers.get(name, StandardFileNamer)
 
 
 class _BaseFileNamer:
-    """File namer base class"""
+    """File namer base class."""
 
     def __init__(self, replace=None, extra=""):
         self._count = 0
@@ -28,8 +28,7 @@ class _BaseFileNamer:
 
 
 class SimpleFileNamer(_BaseFileNamer):
-    """
-    Simple file namer class.
+    """Simple file namer class.
 
     Generates numbered file names.
     """
@@ -38,8 +37,7 @@ class SimpleFileNamer(_BaseFileNamer):
 
 
 class StandardFileNamer(SimpleFileNamer):
-    """
-    Standard file namer class.
+    """Standard file namer class.
 
     Generates file names based on input dataset.
     """
@@ -79,10 +77,7 @@ class StandardFileNamer(SimpleFileNamer):
             return None
 
     def _resolve_derived_attrs(self, ds, attrs, template, fmt=None):
-        """
-        Finds var_id, time_range and format_extension of dataset and output to
-        generate output file name.
-        """
+        """Finds var_id, time_range and format_extension of dataset and output to generate output file name."""
         if "__derive__var_id" in template:
             attrs["__derive__var_id"] = xu.get_main_variable(ds)
 

--- a/clisops/utils/output_utils.py
+++ b/clisops/utils/output_utils.py
@@ -47,7 +47,7 @@ def get_format_extension(fmt):
 
 
 def _format_time(tm: Union[str, dt], fmt="%Y-%m-%d"):
-    """Convert to datetime if time is a numpy datetime"""
+    """Convert to datetime if time is a numpy datetime."""
     if not hasattr(tm, "strftime"):
         tm = pd.to_datetime(str(tm))
 
@@ -92,7 +92,6 @@ def get_time_slices(
 ) -> List[Tuple[str, str]]:
 
     """
-
     Take an xarray Dataset or DataArray, assume it can be split on the time axis
     into a sequence of slices. Optionally, take a start and end date to specify
     a sub-slice of the main time axis.
@@ -103,12 +102,12 @@ def get_time_slices(
 
     Parameters
     ----------
-    ds: Union[xr.Dataset, xr.DataArray]
+    ds : Union[xr.Dataset, xr.DataArray]
     split_method
     start
     end
-    file_size_limit: str
-      a string specifying "<number><units>".
+    file_size_limit : str
+        a string specifying "<number><units>".
 
     Returns
     -------
@@ -164,8 +163,7 @@ def get_time_slices(
 
 
 def get_chunk_length(da):
-    """
-    Calculate the chunk length to use when chunking xarray datasets.
+    """Calculate the chunk length to use when chunking xarray datasets.
 
     Based on memory limit provided in config and the size of the dataset.
     """
@@ -184,9 +182,7 @@ def get_chunk_length(da):
 
 
 def _get_chunked_dataset(ds):
-    """
-    Chunk xr.Dataset and return chunked dataset
-    """
+    """Chunk xr.Dataset and return chunked dataset."""
     da = get_da(ds)
     chunk_length = get_chunk_length(da)
     chunked_ds = ds.chunk({"time": chunk_length})
@@ -194,10 +190,7 @@ def _get_chunked_dataset(ds):
 
 
 def get_output(ds, output_type, output_dir, namer):
-    """
-    Return output after applying chunking and determining
-    the output format and chunking
-    """
+    """Return output after applying chunking and determining the output format and chunking."""
     format_writer = get_format_writer(output_type)
     logger.info(f"format_writer={format_writer}, output_type={output_type}")
 

--- a/clisops/utils/time_utils.py
+++ b/clisops/utils/time_utils.py
@@ -1,6 +1,6 @@
 def create_time_bounds(ds, freq):
-    """
-    Generate time bounds for datasets that have been temporally averaged.
+    """Generate time bounds for datasets that have been temporally averaged.
+
     Averaging frequencies supported are yearly, monthly and daily.
     """
     # get datetime class

--- a/clisops/utils/tutorial.py
+++ b/clisops/utils/tutorial.py
@@ -88,7 +88,7 @@ def get_file(
     name : Union[str, Sequence[str]]
         Name of the file or list/tuple of names of files containing the dataset(s) including suffixes.
     github_url : str
-        URL to Github repository where the data is stored.
+        URL to GitHub repository where the data is stored.
     branch : str, optional
         For GitHub-hosted files, the branch to download from.
     cache_dir : Path
@@ -137,7 +137,7 @@ def query_folder(
     pattern : str, optional
         Regex pattern to identify a file.
     github_url : str
-        URL to Github repository where the data is stored.
+        URL to GitHub repository where the data is stored.
     branch : str, optional
         For GitHub-hosted files, the branch to download from.
 
@@ -189,7 +189,7 @@ def open_dataset(
     dap_url : str, optional
         URL to OPeNDAP folder where the data is stored. If supplied, supersedes github_url.
     github_url : str
-        URL to Github repository where the data is stored.
+        URL to GitHub repository where the data is stored.
     branch : str, optional
         For GitHub-hosted files, the branch to download from.
     cache_dir : Path

--- a/tests/core/test_average.py
+++ b/tests/core/test_average.py
@@ -199,7 +199,7 @@ class TestAverageTime:
         ds = xu.open_xr_dataset(self.month_ds)
 
         with pytest.raises(InvalidParameterValue) as exc:
-            average.average_time(ds, freq=None)
+            average.average_time(ds, freq=None)  # noqa
         assert str(exc.value) == "At least one frequency for averaging must be provided"
 
     def test_incorrect_freq(self):
@@ -216,7 +216,7 @@ class TestAverageTime:
         ds = xu.open_xr_dataset(self.month_ds)
 
         with pytest.raises(InvalidParameterValue) as exc:
-            average.average_time(ds, freq=0)
+            average.average_time(ds, freq=0)  # noqa
         assert str(exc.value) == "At least one frequency for averaging must be provided"
 
     def test_no_time(self):

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -62,7 +62,7 @@ class TestSubsetTime:
         yr_st = "1776"
         yr_ed = "2077"
 
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             out = subset.subset_time(
                 da, start_date=f"{yr_st}-01", end_date=f"{yr_ed}-01"
             )
@@ -87,18 +87,18 @@ class TestSubsetTime:
         with pytest.raises(TypeError):
             subset.subset_time(da, start_yr=2050, end_yr=2059)
 
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             subset.subset_time(
                 da,
-                start_date=2050,
-                end_date=2055,
+                start_date=2050,  # noqa
+                end_date=2055,  # noqa
             )
         assert (
             'start_date and end_date require dates in (type: str) using formats of "%Y", "%Y-%m" or "%Y-%m-%d".'
             in [str(q.message) for q in record]
         )
 
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             subset.subset_time(
                 da, start_date="2064-01-01T00:00:00", end_date="2065-02-01T03:12:01"
             )
@@ -118,19 +118,19 @@ class TestSubsetTime:
         yr_st = "2050"
 
         # start date only
-        with pytest.warns(None):
+        with pytest.warns(None):  # noqa
             out = subset.subset_time(da, start_date=f"{yr_st}-01")
         np.testing.assert_array_equal(out.time.dt.year.min(), int(yr_st))
         np.testing.assert_array_equal(out.time.dt.year.max(), da.time.dt.year.max())
 
-        with pytest.warns(None):
+        with pytest.warns(None):  # noqa
             out = subset.subset_time(da, start_date=f"{yr_st}-07")
         np.testing.assert_array_equal(out.time.dt.year.min(), int(yr_st))
         np.testing.assert_array_equal(out.time.min().dt.month, 7)
         np.testing.assert_array_equal(out.time.dt.year.max(), da.time.dt.year.max())
         np.testing.assert_array_equal(out.time.max(), da.time.max())
 
-        with pytest.warns(None):
+        with pytest.warns(None):  # noqa
             out = subset.subset_time(da, start_date=f"{yr_st}-07-15")
         np.testing.assert_array_equal(out.time.dt.year.min(), int(yr_st))
         np.testing.assert_array_equal(out.time.min().dt.month, 7)
@@ -143,14 +143,14 @@ class TestSubsetTime:
         yr_ed = "2059"
 
         # end date only
-        with pytest.warns(None):
+        with pytest.warns(None):  # noqa
             out = subset.subset_time(da, end_date=f"{yr_ed}-01")
         np.testing.assert_array_equal(out.time.dt.year.max(), int(yr_ed))
         np.testing.assert_array_equal(out.time.max().dt.month, 1)
         np.testing.assert_array_equal(out.time.max().dt.day, 31)
         np.testing.assert_array_equal(out.time.min(), da.time.min())
 
-        with pytest.warns(None):
+        with pytest.warns(None):  # noqa
             out = subset.subset_time(da, end_date=f"{yr_ed}-06-15")
         np.testing.assert_array_equal(out.time.dt.year.max(), int(yr_ed))
         np.testing.assert_array_equal(out.time.max().dt.month, 6)
@@ -655,7 +655,7 @@ class TestSubsetBbox:
             subset.subset_bbox(
                 da, lon_bnds=self.lon, lat_bnds=self.lat, start_yr=2050, end_yr=2059
             )
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             subset.subset_bbox(
                 da,
                 lon_bnds=self.lon,
@@ -743,7 +743,7 @@ class TestSubsetShape:
     def test_no_wraps(self, tmp_netcdf_filename):
         ds = xr.open_dataset(self.nc_file)
 
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             sub = subset.subset_shape(ds, self.poslons_geojson)
 
         self.compare_vals(ds, sub, "tas")
@@ -774,7 +774,7 @@ class TestSubsetShape:
     def test_all_neglons(self):
         ds = xr.open_dataset(self.nc_file_neglons)
 
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             sub = subset.subset_shape(ds, self.southern_qc_geojson)
 
         self.compare_vals(ds, sub, "tasmax")
@@ -793,7 +793,7 @@ class TestSubsetShape:
     def test_rotated_pole_with_time(self):
         ds = xr.open_dataset(self.lons_2d_nc_file)
 
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             sub = subset.subset_shape(
                 ds,
                 self.eastern_canada_geojson,
@@ -961,7 +961,7 @@ class TestSubsetLevel:
         lev_st = 10000000
         lev_ed = 10
 
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             out = subset.subset_level(da, first_level=lev_st, last_level=lev_ed)
 
         np.testing.assert_array_equal(out.plev.min(), da.plev.min())
@@ -982,14 +982,14 @@ class TestSubsetLevel:
         with pytest.raises(TypeError):
             subset.subset_level(da, first_level=da, last_level=da)
 
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             subset.subset_level(da, first_level="1000", last_level="1000")
         assert (
             '"first_level" should be a number, it has been converted to a float.'
             in [str(q.message) for q in record]
         )
 
-        with pytest.warns(None) as record:
+        with pytest.warns(None) as record:  # noqa
             subset.subset_level(da, first_level=81200, last_level=54100.6)
 
         msgs = {
@@ -1003,7 +1003,7 @@ class TestSubsetLevel:
         lev_st = 100000
 
         # first level only
-        with pytest.warns(None):
+        with pytest.warns(None):  # noqa
             out = subset.subset_level(da, first_level=lev_st, last_level=lev_st)
 
         np.testing.assert_array_equal(out.plev.values[0], da.plev.values[0])
@@ -1014,13 +1014,13 @@ class TestSubsetLevel:
         # good_levels = [40000, 30000]
         # good_indices = [6, 7]
 
-        with pytest.warns(None):
+        with pytest.warns(None):  # noqa
             out = subset.subset_level(da, first_level=37000.2342, last_level=27777)
 
         np.testing.assert_array_equal(out.plev.values[0], da.plev.values[7])
         np.testing.assert_array_equal(out.plev.values[-1], da.plev.values[7])
 
-        with pytest.warns(None):
+        with pytest.warns(None):  # noqa
             out = subset.subset_level(da, first_level=41562, last_level=29999)
 
         np.testing.assert_array_equal(out.plev.values[:], da.plev.values[6:8])

--- a/tests/ops/test_average.py
+++ b/tests/ops/test_average.py
@@ -1,13 +1,9 @@
 import os
-import sys
-from unittest.mock import Mock
 
 import pytest
 import xarray as xr
 from roocs_utils.exceptions import InvalidParameterValue
 
-import clisops
-from clisops import CONFIG
 from clisops.ops.average import average_over_dims, average_time
 
 from .._common import C3S_CORDEX_EUR_ZG500, CMIP5_TAS, CMIP6_SICONC_DAY
@@ -147,7 +143,7 @@ def test_average_multiple_dims_xarray():
     assert "lon" not in result[0]
 
 
-def test_average_no_dims(tmpdir):
+def test_average_no_dims():
     with pytest.raises(InvalidParameterValue) as exc:
         average_over_dims(
             CMIP5_TAS,
@@ -288,7 +284,7 @@ def test_average_time_no_freq():
         # average over time
         average_time(
             CMIP6_SICONC_DAY,
-            freq=None,
+            freq=None,  # noqa
             output_type="xarray",
         )
     assert str(exc.value) == "At least one frequency for averaging must be provided"

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -1105,7 +1105,7 @@ def test_curvilinear_ds_no_data_in_bbox():
     assert (
         str(exc.value)
         == "There were no valid data points found in the requested subset. "
-           "Please expand the area covered by the bounding box."
+        "Please expand the area covered by the bounding box."
     )
 
 

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -16,7 +16,7 @@ from roocs_utils.parameter.param_utils import (
 
 from clisops import CONFIG
 from clisops.ops.subset import Subset, subset
-from clisops.utils.output_utils import _format_time
+from clisops.utils.output_utils import _format_time  # noqa
 
 from .._common import (
     C3S_CMIP5_TOS,
@@ -108,7 +108,7 @@ def test_subset_ds_is_none(tmpdir):
     """Tests subset with ds=None."""
     with pytest.raises(InvalidParameterValue):
         subset(
-            ds=None,
+            ds=None,  # noqa
             time=time_interval("2020-01-01T00:00:00", "2020-12-30T00:00:00"),
             area=(0, -90.0, 360.0, 90.0),
             output_dir=tmpdir,
@@ -122,7 +122,7 @@ def test_subset_no_ds(tmpdir):
             time=time_interval("2020-01-01T00:00:00", "2020-12-30T00:00:00"),
             area=(0, -90.0, 360.0, 90.0),
             output_dir=tmpdir,
-        )
+        )  # noqa
 
 
 def test_subset_area_simple_file_name(cmip5_tas_file, tmpdir):
@@ -1104,7 +1104,8 @@ def test_curvilinear_ds_no_data_in_bbox():
         )
     assert (
         str(exc.value)
-        == "There were no valid data points found in the requested subset. Please expand the area covered by the bounding box."
+        == "There were no valid data points found in the requested subset. "
+           "Please expand the area covered by the bounding box."
     )
 
 

--- a/tests/test_utils/test_dataset_utils.py
+++ b/tests/test_utils/test_dataset_utils.py
@@ -1,4 +1,4 @@
-import cf_xarray as cfxr
+import cf_xarray as cfxr  # noqa
 import numpy as np
 import pytest
 import xarray as xr
@@ -116,7 +116,7 @@ def test_detect_coordinate_and_bounds():
 
 
 def test_detect_gridtype():
-    "Test the function detect_gridtype"
+    """Test the function detect_gridtype."""
     ds_a = xr.open_dataset(CMIP6_UNSTR_ICON_A, use_cftime=True)
     ds_b = xr.open_dataset(CMIP6_TOS_ONE_TIME_STEP, use_cftime=True)
     ds_c = xr.open_dataset(CMIP6_TAS_ONE_TIME_STEP, use_cftime=True)
@@ -149,7 +149,7 @@ def test_detect_gridtype():
 
 
 def test_crosses_0_meridian():
-    "Test the _crosses_0_meridian function"
+    """Test the _crosses_0_meridian function"""
     # Case 1 - longitude crossing 180° meridian
     lon = np.arange(160.0, 200.0, 1.0)
 
@@ -173,7 +173,7 @@ def test_crosses_0_meridian():
 
 
 def test_convert_interval_between_lon_frames():
-    "Test the helper function _convert_interval_between_lon_frames"
+    """Test the helper function _convert_interval_between_lon_frames"""
     # Convert from 0,360 to -180,180 longitude frame and vice versa
     assert clidu._convert_interval_between_lon_frames(20, 60) == (20, 60)
     assert clidu._convert_interval_between_lon_frames(190, 200) == (-170, -160)
@@ -193,7 +193,7 @@ def test_convert_interval_between_lon_frames():
 
 
 def test_convert_lon_frame_bounds():
-    "Test the function cf_convert_between_lon_frames"
+    """Test the function cf_convert_between_lon_frames"""
     # Load tutorial dataset defined on [200,330]
     ds = xr.tutorial.open_dataset("air_temperature")
     assert ds["lon"].min() == 200.0
@@ -208,7 +208,7 @@ def test_convert_lon_frame_bounds():
     assert conv["lon"].values[0] == -160.0
     assert conv["lon"].values[-1] == -30.0
 
-    # Check bounds are containing the respective cell centers
+    # Check that bounds contain the respective cell centers
     assert np.all(conv["lon"].values[:] > conv["lon_bounds"].values[0, :])
     assert np.all(conv["lon"].values[:] < conv["lon_bounds"].values[1, :])
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #250 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
- converts nearly all docstring tests that were skipped into python code blocks for documentation purposes
- fixes some annoying static type hinting misattributions.
- Fixes the xarray-related changes that were not fully addressed in 0.9.2
- Adjusts the conda-xesmf GitHub Actions build to use the latest available with Python3.9.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No.

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
