### PR TITLE
fix subset level by values with method=nearest

### DIFF
--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1774,7 +1774,7 @@ def subset_level_by_values(
     input dataset.
     """
     level = xu.get_coord_by_type(da, "level")
-    return da.sel(**{level.name: level_values})
+    return da.sel(**{level.name: level_values}, method="nearest")
 
 
 @convert_lat_lon_to_da


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Bug fix

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->

`subset_level_by_values` didn't work for CMIP6 dataset. Needed to add `method="nearest"` to `ds.sel` to make it work.

The example notebook (Process error: Requested levels include some not found in the dataset: 1000.0):
https://nbviewer.org/github/roocs/rooki/blob/master/notebooks/demo/rook-errors-2022-12-08.ipynb