### PR TITLE
fix subset_bbox with level_values

### DIFF
--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1287,13 +1287,13 @@ def subset_bbox(
         da = subset_time(da, start_date=start_date, end_date=end_date)
 
     elif time_values:
-        da = subset_time_by_values(da, time_values)
+        da = subset_time_by_values(da, time_values=time_values)
 
     if first_level or last_level:
         da = subset_level(da, first_level=first_level, last_level=last_level)
 
     elif level_values:
-        da = subset_level_by_values(da, level_values)
+        da = subset_level_by_values(da, level_values=level_values)
 
     if da[lat].size == 0 or da[lon].size == 0:
         raise ValueError(

--- a/tests/ops/test_subset.py
+++ b/tests/ops/test_subset.py
@@ -1418,6 +1418,30 @@ def test_subset_level_by_values_with_gaps(tmpdir, load_esgf_test_data):
     assert_vars_equal("plev", *ds_list)
 
 
+def test_subset_level_by_values_and_bbox(tmpdir, load_esgf_test_data):
+    some_levels = [60000, 50000, 40000, 30000, 25000, 20000, 15000, 10000, 7000, 5000]
+    area = (20, 30.0, 150, 70.0)
+
+    shuffled_1 = _shuffle(some_levels)
+    shuffled_2 = _shuffle(some_levels)
+
+    # Get various outputs and compare they are the same
+    ds_list = [
+        subset(
+            ds=CMIP6_TA, output_dir=tmpdir, output_type="xarray", level=level, area=area
+        )[0]
+        for level in [
+            level_series(some_levels),
+            level_interval(some_levels[0], some_levels[-1]),
+            level_series(list(reversed(some_levels))),
+            level_series(shuffled_1),
+            level_series(shuffled_2),
+        ]
+    ]
+
+    assert_vars_equal("plev", *ds_list)
+
+
 def test_subset_time_by_values_all(tmpdir, load_esgf_test_data):
     all_times = [str(tm) for tm in xr.open_dataset(CMIP6_TA).time.values]
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Bug fix

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
no

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->

`subset_bbox` raise an exception when used both with `area` and `level_values` parameter:
```
subset_level_by_values got multiple values for argument level_values
```

This PR fixes this issue. The parameter keyword `level_values` was missing needed by the `check_levels_exist` decorator.

See rooki notebook to reproduce the issue:
https://nbviewer.org/github/roocs/rooki/blob/master/notebooks/demo/rook-errors-2022-12-08.ipynb