### PR TITLE
fix check_levels_exist decorator

### DIFF
--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -286,7 +286,8 @@ def check_levels_exist(func):
 
         req_levels = set(kwargs.get("level_values", set()))
         da_levels = xu.get_coord_by_type(da, "level")
-        levels = {lev for lev in da_levels.values}
+        # round levels to precision 4. There might be level values like 1000.00000001 ... which would not match to 1000
+        levels = {round(lev, 4) for lev in da_levels.values}
 
         if not req_levels.issubset(levels):
             mismatch_levels = req_levels.difference(levels)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
bug fix

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
no

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
This PR is a follow up fix for PR #262. It fixes the `check_levels_exist` decorator to handle level values like 1000.00000001. It rounds them to precision 4 to match them with the correct value 1000.0. 

