### PR TITLE
Add support for locstream lon/lat in bbox and shape subsetting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Bug Fixes
 ^^^^^^^^^
 * Fixed bug in `core.subset.shape_bbox_indexer` with the union of invalid geometries. Added regression test. (Issue #280)
 * Added support in `core.subset.shape_bbox_indexer` for Point and MultiPoint geometries. (Issue #283)
+* Fixed `core.subset.subset_bbox` and `core.subset.subset_shape` for datasets with 1D longitude and latitude (ex : Station data).
 
 v0.9.6 (2023-04-05)
 -------------------

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1250,8 +1250,10 @@ def subset_bbox(
     # Locstream case (lat and lon are 1D, sharing the dimension)
     elif da[lat].ndim == 1 and da[lon].ndim == 1 and da[lon].dims == da[lat].dims:
         mask = (
-            (da[lat] < max(lat_bnds)) & (da[lat] > min(lat_bnds))
-            & (da[lon] < max(lon_bnds)) & (da[lon] > min(lon_bnds))
+            (da[lat] < max(lat_bnds))
+            & (da[lat] > min(lat_bnds))
+            & (da[lon] < max(lon_bnds))
+            & (da[lon] > min(lon_bnds))
         )
         da = da.sel({da[lat].dims[0]: mask})
 

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -671,8 +671,11 @@ class TestSubsetBbox:
     def test_locstream(self):
         da = xr.DataArray(
             [1, 2, 3, 4],
-            dims=('site',),
-            coords={'lat': (('site',), [10, 30, 20, 40]), 'lon': (('site',), [-50, -80, -70, -100])}
+            dims=("site",),
+            coords={
+                "lat": (("site",), [10, 30, 20, 40]),
+                "lon": (("site",), [-50, -80, -70, -100]),
+            },
         )
         sub = subset.subset_bbox(da, lon_bnds=[-95, -65], lat_bnds=[15, 35])
         exp = da.isel(site=[1, 2])
@@ -895,8 +898,11 @@ class TestSubsetShape:
     def test_locstream(self):
         da = xr.DataArray(
             [1, 2, 3, 4],
-            dims=('site',),
-            coords={'lat': (('site',), [10, 30, 20, 40]), 'lon': (('site',), [-50, -80, -70, -100])}
+            dims=("site",),
+            coords={
+                "lat": (("site",), [10, 30, 20, 40]),
+                "lon": (("site",), [-50, -80, -70, -100]),
+            },
         )
         poly = Polygon([[-90, 15], [-65, 15], [-65, 35], [-90, 35]])
         shape = gpd.GeoDataFrame(geometry=[poly])

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -668,6 +668,16 @@ class TestSubsetBbox:
             not in [str(q.message) for q in record]
         )
 
+    def test_locstream(self):
+        da = xr.DataArray(
+            [1, 2, 3, 4],
+            dims=('site',),
+            coords={'lat': (('site',), [10, 30, 20, 40]), 'lon': (('site',), [-50, -80, -70, -100])}
+        )
+        sub = subset.subset_bbox(da, lon_bnds=[-95, -65], lat_bnds=[15, 35])
+        exp = da.isel(site=[1, 2])
+        xr.testing.assert_identical(sub, exp)
+
 
 class TestSubsetShape:
     nc_file = get_file("cmip5/tas_Amon_CanESM2_rcp85_r1i1p1_200701-200712.nc")
@@ -881,6 +891,18 @@ class TestSubsetShape:
         )
         sub = subset.subset_shape(da, shape=shape)
         assert sub.notnull().sum() == 3
+
+    def test_locstream(self):
+        da = xr.DataArray(
+            [1, 2, 3, 4],
+            dims=('site',),
+            coords={'lat': (('site',), [10, 30, 20, 40]), 'lon': (('site',), [-50, -80, -70, -100])}
+        )
+        poly = Polygon([[-90, 15], [-65, 15], [-65, 35], [-90, 35]])
+        shape = gpd.GeoDataFrame(geometry=[poly])
+        sub = subset.subset_shape(da, shape=shape)
+        exp = da.isel(site=[1, 2])
+        xr.testing.assert_identical(sub, exp)
 
 
 class TestDistance:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Adds the case for a dataset where the lon and lat coords are 1D and share a dimension. This is the case for station data, for example.  "locstream"  is the word used in ESMF, I didn't have a better idea.

The changes are located in mostly `subset_bbox`, but it also required a small change in `create_masks` so that `subset_shape` would work too.

In `subset_bbox`, for the curvilinear case, I also removed `drop=True` from the code. It is not doing anything because we are already clipping to the smallest box above, but more importantly, if it was doing anything it would fail in the dataset case. Some var would have coords dropped and be added back in the dataset, where the full coords still exist.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No.

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
@vindelico @sarahclaude