### PR TITLE
Remove deprecated  `pygeos`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,10 @@ Bug Fixes
 * Fixed bug in `core.subset.shape_bbox_indexer` with the union of invalid geometries. Added regression test. (Issue #280)
 * Added support in `core.subset.shape_bbox_indexer` for Point and MultiPoint geometries. (Issue #283)
 
+Other Changes
+^^^^^^^^^^^^^
+* Shapely 2.0 is now faster than pygeos for ``create_mask``. Remove pygeos as extra dependency and pin shapely.
+
 v0.9.6 (2023-04-05)
 -------------------
 

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional, Sequence, Tuple, Union
 import cf_xarray  # noqa
 import geopandas as gpd
 import numpy as np
+import shapely as shp
 import xarray
 from packaging import version
 from pandas import DataFrame
@@ -18,14 +19,12 @@ from pyproj.crs import CRS
 from pyproj.exceptions import CRSError
 from roocs_utils.utils.time_utils import to_isoformat
 from roocs_utils.xarray_utils import xarray_utils as xu
-import shapely as shp
 from shapely import vectorized
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.ops import split, unary_union
 from xarray.core.utils import get_temp_dimname
 
 from clisops.utils.dataset_utils import adjust_date_to_calendar
-
 
 __all__ = [
     "create_mask",
@@ -551,15 +550,11 @@ def create_mask(
     geoms = poly.geometry.values
     mask = np.full(lat1.shape, np.nan)
     for val, geom in zip(poly.index[::-1], geoms[::-1]):
-        contained = (
-            vectorized
-            .contains(geom, lon1.flatten(), lat1.flatten())
-            .reshape(lat1.shape)
+        contained = vectorized.contains(geom, lon1.flatten(), lat1.flatten()).reshape(
+            lat1.shape
         )
-        touched = (
-            vectorized
-            .touches(geom, lon1.flatten(), lat1.flatten())
-            .reshape(lat1.shape)
+        touched = vectorized.touches(geom, lon1.flatten(), lat1.flatten()).reshape(
+            lat1.shape
         )
         intersection = np.logical_or(contained, touched)
         mask[intersection] = val

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -9,7 +9,6 @@ from typing import Dict, Optional, Sequence, Tuple, Union
 import cf_xarray  # noqa
 import geopandas as gpd
 import numpy as np
-import shapely as shp
 import xarray
 from packaging import version
 from pandas import DataFrame

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,9 +29,6 @@ you through the process.
    on packages (ESMF, ESMpy) unavailable on windows.  It can still be installed on osx/linux through `conda` or
    directly [from source](https://github.com/pangeo-data/xESMF/).
 
-Another optional dependency is [pygeos](https://pygeos.readthedocs.io/en/latest/index.html). If installed,
-the performance of `core.subset.create_mask` and `core.subset.subset_shape` are greatly improved.
-
 From sources
 ------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
  - pooch
  - requests>=2.0
  - roocs-utils>=0.6.4,<0.7
- - shapely >=2
+ - shapely >=1.9
  - sparse >=0.8.0  # needed for xesmf v0.6.3, see: https://github.com/conda-forge/xesmf-feedstock/pull/24
  - xarray >=0.21
  - xesmf >=0.6.3

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
  - pooch
  - requests>=2.0
  - roocs-utils>=0.6.4,<0.7
- - shapely >=1.9
+ - shapely >=2
  - sparse >=0.8.0  # needed for xesmf v0.6.3, see: https://github.com/conda-forge/xesmf-feedstock/pull/24
  - xarray >=0.21
  - xesmf >=0.6.3

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ docs_requirements = [
     "matplotlib",
 ]
 
-extra_requirements = ["xesmf>=0.6.2", "pygeos>=0.9"]
+extra_requirements = ["xesmf>=0.6.2"]
 
 setup(
     version=about["__version__"],

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -847,7 +847,7 @@ class TestSubsetShape:
         assert ds_sub.notnull().sum() == 58 + 250 + 22
         assert ds_sub.tas.shape == (12, 14, 128)
 
-    def test_vectorize_touches_polygons(self, toggle_pygeos):
+    def test_vectorize_touches_polygons(self):
         """Check that points touching the polygon are included in subset."""
         # Create simple polygon
         poly = Polygon([[0, 0], [1, 0], [1, 1]])

--- a/tests/core/test_subset.py
+++ b/tests/core/test_subset.py
@@ -16,27 +16,6 @@ try:
 except ImportError:
     xesmf = None
 
-try:
-    import pygeos
-except ImportError:
-    pygeos = None
-
-
-@pytest.fixture(params=[True, False])
-def toggle_pygeos(request):
-    if request.param:
-        if pygeos is None:
-            pytest.skip("pygeos not installed")
-        else:
-            yield request.param
-    else:
-        # Do not use pygeos
-        mod = subset.pygeos
-        # Monkeypatch core.subset to imitate the absence of pygeos.
-        subset.pygeos = None
-        yield request.param
-        subset.pygeos = mod
-
 
 class TestSubsetTime:
     nc_poslons = get_file("cmip3/tas.sresb1.giss_model_e_r.run1.atm.da.nc")
@@ -836,7 +815,7 @@ class TestSubsetShape:
         with xr.open_dataset(filename_or_obj=tmp_netcdf_filename) as f:
             assert {"tas", "crs"}.issubset(set(f.data_vars))
 
-    def test_mask_multiregions(self, toggle_pygeos):
+    def test_mask_multiregions(self):
         ds = xr.open_dataset(self.nc_file)
         regions = gpd.read_file(self.multi_regions_geojson)
         regions.set_index("id")


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Remove the pygeos "fast-path" in `create_mask`. The improvements of `pygeos` are now integrated in shapely 2.0 and the latest geopandas. Moreover, when testing with shapely 2.0.1, the "slow" path that used "shapely.vectorized" was much faster than the "fast" one with pygeos.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
No. 

A specific env with shapely < 2 and pygeos installed, might be slower with this branch than before. But I'm assuming shapely 2 would be way more common. Also, it's only a minor performance improvement.

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
