### PR TITLE
Regridding: handling of zonal mean datasets and datasets with shifted longitude frame

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,17 @@
 Version History
 ===============
 
+v0.12.2 (unreleased)
+--------------------
+
+Bug Fixes
+^^^^^^^^^
+* Now also applying fix for datasets with shifted longitude frames (#218) for the regrid operator (#313).
+
+Other Changes
+^^^^^^^^^^^^^
+* Warnings are now emitted when the user attempts to regrid a zonal mean dataset (#313).
+
 v0.12.1 (2023-11-30)
 --------------------
 

--- a/clisops/core/regrid.py
+++ b/clisops/core/regrid.py
@@ -704,6 +704,20 @@ class Grid:
         yfirst = float(self.ds[self.lat].min())
         ylast = float(self.ds[self.lat].max())
 
+        # Perform roll if necessary
+        if xfirst < 0:
+            self.ds, low, high = clidu.cf_convert_between_lon_frames(
+                self.ds, [-180.0, 180.0]
+            )
+        else:
+            self.ds, low, high = clidu.cf_convert_between_lon_frames(
+                self.ds, [0.0, 360.0]
+            )
+
+        # Determine min/max lon/lat values
+        xfirst = float(self.ds[self.lon].min())
+        xlast = float(self.ds[self.lon].max())
+
         # Approximate the grid resolution
         if self.ds[self.lon].ndim == 2 and self.ds[self.lat].ndim == 2:
             xsize = self.nlon

--- a/clisops/core/regrid.py
+++ b/clisops/core/regrid.py
@@ -755,6 +755,10 @@ class Grid:
         #        lon_min - approx_xres / 2.0,
         #        lon_max + approx_xres / 2.0,
         #    )
+        elif np.isclose(lon_min, lon_max):
+            raise Exception(
+                "Remapping zonal mean datasets or generally datasets without meridional extent is not supported."
+            )
         else:
             raise Exception(
                 "The longitude values have to be within the range (-180, 360)."

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -338,6 +338,11 @@ CORDEX_TAS_ONE_TIMESTEP = Path(
     "master/test_data/pool/data/CORDEX/data/cordex/output/EUR-22/GERICS/MPI-M-MPI-ESM-LR/rcp85/r1i1p1/GERICS-REMO2015/v1/mon/tas/v20191029/tas_EUR-22_MPI-M-MPI-ESM-LR_rcp85_r1i1p1_GERICS-REMO2015_v1_mon_202101.nc",
 ).as_posix()
 
+CORDEX_TAS_ONE_TIMESTEP_ANT = Path(
+    MINI_ESGF_CACHE_DIR,
+    "master/test_data/pool/data/CORDEX/data/cordex/output/ANT-44/KNMI/ECMWF-ERAINT/evaluation/r1i1p1/DMI-HIRHAM5/v1/day/tas/v20201001/tas_ANT-44_ECMWF-ERAINT_evaluation_r1i1p1_DMI-HIRHAM5_v1_day_20060101.nc",
+).as_posix()
+
 # CORDEX dataset on regional curvilinear grid without defined bounds
 CORDEX_TAS_NO_BOUNDS = Path(
     MINI_ESGF_CACHE_DIR,

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -265,6 +265,12 @@ CMIP6_ATM_VERT_ONE_TIMESTEP = Path(
     "master/test_data/badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/AERmon/o3/gn/v20190710/o3_AERmon_MPI-ESM1-2-LR_historical_r1i1p1f1_gn_185001.nc",
 ).as_posix()
 
+# cdo zonmean of CMIP6 dataset with vertical axis (lon singleton dimension)
+CMIP6_ATM_VERT_ONE_TIMESTEP_ZONMEAN = Path(
+    MINI_ESGF_CACHE_DIR,
+    "master/test_data/badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/AERmon/o3/gn/v20190710/o3_AERmon_MPI-ESM1-2-LR_historical_r1i1p1f1_gn_185001_zm.nc",
+).as_posix()
+
 # CMIP6 2nd dataset with weird range in its longitude coordinate (-280, 80)
 CMIP6_IITM_EXTENT = Path(
     MINI_ESGF_CACHE_DIR,
@@ -313,6 +319,17 @@ CMIP6_STAGGERED_VCOMP = Path(
 CMIP6_FILLVALUE = Path(
     MINI_ESGF_CACHE_DIR,
     "master/test_data/pool/data/CMIP6/data/CMIP6/CMIP/NCAR/CESM2-WACCM/historical/r1i1p1f1/day/tas/gn/v20190227/tas_day_CESM2-WACCM_historical_r1i1p1f1_gn_20000101-20091231.nc",
+).as_posix()
+
+# CMIP6 zonal mean datasets
+CMIP6_ZONMEAN_A = Path(
+    MINI_ESGF_CACHE_DIR,
+    "master/test_data/badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/Omon/msftmz/gn/v20190710/msftmz_Omon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_191001.nc",
+).as_posix()
+
+CMIP6_ZONMEAN_B = Path(
+    MINI_ESGF_CACHE_DIR,
+    "master/test_data/badc/cmip6/data/CMIP6/CMIP/NCC/NorCPM1/historical/r22i1p1f1/Omon/msftmz/grz/v20200724/msftmz_Omon_NorCPM1_historical_r22i1p1f1_grz_185001.nc",
 ).as_posix()
 
 # CORDEX dataset on regional curvilinear grid

--- a/tests/test_core_regrid.py
+++ b/tests/test_core_regrid.py
@@ -14,6 +14,7 @@ from _common import (
     CMIP6_ATM_VERT_ONE_TIMESTEP,
     CMIP6_ATM_VERT_ONE_TIMESTEP_ZONMEAN,
     CMIP6_GFDL_EXTENT,
+    CMIP6_IITM_EXTENT,
     CMIP6_OCE_HALO_CNRM,
     CMIP6_STAGGERED_UCOMP,
     CMIP6_TAS_ONE_TIME_STEP,
@@ -25,6 +26,7 @@ from _common import (
     CMIP6_ZONMEAN_B,
     CORDEX_TAS_NO_BOUNDS,
     CORDEX_TAS_ONE_TIMESTEP,
+    CORDEX_TAS_ONE_TIMESTEP_ANT,
 )
 from clisops import CONFIG
 from clisops.core.regrid import (
@@ -150,6 +152,72 @@ def test_grid_init_ds_tas_cordex(load_esgf_test_data):
         match="The grid format is not supported.",
     ):
         Grid(ds=ds)
+
+
+def test_grid_init_ds_tas_cordex_ant(load_esgf_test_data):
+    ds = xr.open_dataset(CORDEX_TAS_ONE_TIMESTEP_ANT, use_cftime=True)
+
+    # assert shifted lon frame
+    assert np.isclose(ds["lon"].min(), -165.7, atol=0.5)
+    assert np.isclose(ds["lon"].max(), 193.1, atol=0.5)
+
+    # Create Grid object
+    grid = Grid(ds=ds)
+
+    # assert fixed shifted lon frame and further attributes
+    assert np.isclose(grid.ds["lon"].min(), -180, atol=0.5)
+    assert np.isclose(grid.ds["lon"].max(), 180, atol=0.5)
+    assert grid.format == "CF"
+    assert grid.source == "Dataset"
+    assert grid.lat == "lat"
+    assert grid.lon == "lon"
+    assert grid.type == "curvilinear"
+    assert grid.extent == "global"  # only extent in longitude is checked
+    assert grid.lat_bnds is None
+    assert grid.lon_bnds is None
+    assert not grid.contains_collapsed_cells
+    assert not grid.contains_duplicated_cells
+    assert grid.nlat == 97
+    assert grid.nlon == 125
+    assert grid.ncells == 12125
+
+
+def test_grid_init_shifted_lon_frame_GFDL():
+    ds = xr.open_dataset(CMIP6_GFDL_EXTENT, use_cftime=True)
+
+    # confirm shifted lon frame
+    assert np.isclose(ds["lon"].min(), -300.0, atol=0.5)
+    assert np.isclose(ds["lon"].max(), 60.0, atol=0.5)
+
+    # Create Grid object
+    grid = Grid(ds=ds)
+
+    # assert fix of shifted lon frame
+    assert np.isclose(grid.ds["lon"].min(), -180.0, atol=0.5)
+    assert np.isclose(grid.ds["lon"].max(), 180.0, atol=0.5)
+    assert np.isclose(grid.ds["lon_bnds"].min(), -180.0, atol=0.5)
+    assert np.isclose(grid.ds["lon_bnds"].max(), 180.0, atol=0.5)
+
+    assert grid.type == "curvilinear"
+    assert grid.extent == "global"
+
+
+def test_grid_init_shifted_lon_frame_IITM():
+    ds = xr.open_dataset(CMIP6_IITM_EXTENT, use_cftime=True)
+
+    # confirm shifted lon frame
+    assert np.isclose(ds["longitude"].min(), -280.0, atol=1.0)
+    assert np.isclose(ds["longitude"].max(), 80.0, atol=1.0)
+
+    # Create Grid object
+    grid = Grid(ds=ds)
+
+    # assert fix of shifted lon frame
+    assert np.isclose(grid.ds["longitude"].min(), -180.0, atol=1.0)
+    assert np.isclose(grid.ds["longitude"].max(), 180.0, atol=1.0)
+
+    assert grid.type == "curvilinear"
+    assert grid.extent == "global"
 
 
 def test_grid_init_ds_tas_unstructured(load_esgf_test_data):

--- a/tests/test_ops_regrid.py
+++ b/tests/test_ops_regrid.py
@@ -200,7 +200,6 @@ def test_regrid_halo_simple(load_esgf_test_data, tmp_path):
     assert ds_out.attrs["regrid_operation"] == "conservative_404x802_36x72"
 
 
-@pytest.mark.xfail
 @pytest.mark.skipif(xe is None, reason=XESMF_IMPORT_MSG)
 def test_regrid_halo_adv(load_esgf_test_data, tmp_path):
     "Test regridding of dataset with a more complex halo."
@@ -217,7 +216,6 @@ def test_regrid_halo_adv(load_esgf_test_data, tmp_path):
         output_type="xarray",
     )[0]
 
-    # After the halo can be properly removed (maybe 1049x1440), the test can be updated
     assert ds_out.attrs["regrid_operation"] == "conservative_1050x1442_36x72"
 
 

--- a/tests/test_ops_regrid.py
+++ b/tests/test_ops_regrid.py
@@ -9,6 +9,7 @@ from roocs_grids import get_grid_file, grid_dict
 from _common import (
     CMIP5_MRSOS_ONE_TIME_STEP,
     CMIP6_ATM_VERT_ONE_TIMESTEP,
+    CMIP6_IITM_EXTENT,
     CMIP6_OCE_HALO_CNRM,
     CMIP6_TOS_ONE_TIME_STEP,
 )
@@ -217,6 +218,25 @@ def test_regrid_halo_adv(load_esgf_test_data, tmp_path):
     )[0]
 
     assert ds_out.attrs["regrid_operation"] == "conservative_1050x1442_36x72"
+
+
+@pytest.mark.skipif(xe is None, reason=XESMF_IMPORT_MSG)
+def test_regrid_shifted_lon_frame(load_esgf_test_data, tmp_path):
+    "Test regridding of dataset with shifted longitude frame."
+    fpath = CMIP6_IITM_EXTENT
+    ds = xr.open_dataset(fpath).isel(time=0)
+
+    weights_cache_init(Path(tmp_path, "weights"))
+
+    ds_out = regrid(
+        ds,
+        method="bilinear",
+        adaptive_masking_threshold=-1,
+        grid=5,
+        output_type="xarray",
+    )[0]
+
+    assert ds_out.attrs["regrid_operation"] == "bilinear_200x360_36x72_peri"
 
 
 @pytest.mark.skipif(xe is None, reason=XESMF_IMPORT_MSG)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #217 for the regrid operator
  - The part dealing with zonal mean datasets is not an open issue.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->
- Remapping tests for zonal mean datasets
- Remapping tests for cordex datasets
- Longitude frame fix (#218) now also applied for remapping
- Remapping tests for shifted longitude frame.

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->
No

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->
 - ~~Further tests required regarding longitude frame fix for remapping~~