### PR TITLE
Fix file namer

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ v0.12.3 (unreleased)
 
 Bug Fixes
 ^^^^^^^^^
+* Fixed standard file-namer fallback method (#318).
 * Fixed KeyError for temporal subsetting by components if not all components can be found in the dataset (#316).
 * Raising KeyError for temporal subsetting by components when no time steps match the selection criteria (#316).
 * Coordinate detection for remapping operator via standard_name if detection via cf-xarray fails / is ambiguous (#316).

--- a/clisops/utils/file_namers.py
+++ b/clisops/utils/file_namers.py
@@ -20,7 +20,7 @@ class _BaseFileNamer:
         self._replace = replace
         self._extra = extra
 
-    def get_file_name(self, ds, fmt=None):
+    def get_file_name(self, ds, fmt="nc"):
         """Generate numbered file names"""
         self._count += 1
         extension = get_format_extension(fmt)
@@ -56,7 +56,7 @@ class StandardFileNamer(SimpleFileNamer):
 
         if not template:
             # Default to parent class namer if no method found
-            return super().get_file_name(ds)
+            return super().get_file_name(ds, fmt)
 
         self._count += 1
 

--- a/clisops/utils/file_namers.py
+++ b/clisops/utils/file_namers.py
@@ -45,10 +45,7 @@ class StandardFileNamer(SimpleFileNamer):
     def _get_project(self, ds):
         """Gets the project name from the input dataset"""
 
-        try:
-            return get_project_name(ds)
-        except Exception:
-            return None
+        return get_project_name(ds)
 
     def get_file_name(self, ds, fmt="nc"):
         """Constructs file name."""

--- a/tests/test_file_namers.py
+++ b/tests/test_file_namers.py
@@ -1,6 +1,7 @@
 import pytest
 import xarray as xr
 from roocs_utils.parameter.param_utils import time_interval
+from roocs_utils.exceptions import InvalidProject
 
 from _common import C3S_CORDEX_NAM_PR, CMIP5_TAS, CMIP6_SICONC
 from clisops import CONFIG
@@ -64,7 +65,7 @@ def test_StandardFileNamer_no_project_match():
     mock_ds = Thing()
     mock_ds.attrs = {}
 
-    with pytest.raises(KeyError):
+    with pytest.raises(InvalidProject):
         s.get_file_name(mock_ds)
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->
Bug fix.

This PR fixes the fallback call of the standard file-namer (`fmt` argument was missing). It also updates the "no_project" test of the standard file-namer which was catching the wrong Exception (`KeyError` instead of `InvalidProject`).

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->
no

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->
