### PR TITLE
Use platformdirs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,11 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install tox
-        run: pip install tox~=4.0
+        run: |
+          python -m pip install tox~=4.0
       - name: Run linting suite
-        run: tox -e ${{ matrix.tox-env }}
+        run: |
+          python -m tox -e ${{ matrix.tox-env }}
 
   pypi:
     name: Python${{ matrix.python-version }} (PyPI + Tox)
@@ -54,7 +56,7 @@ jobs:
         python -m pip install tox~=4.0
     - name: Test with tox
       run: |
-        tox -e ${{ matrix.tox-env }}
+        python -m tox -e ${{ matrix.tox-env }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_FLAG_NAME: run-${{ matrix.tox-env }}
@@ -103,9 +105,10 @@ jobs:
       - name: Check versions
         run: |
           conda list
+          python -m pip check || true
       - name: Test with conda
         run: |
-          pytest --cov tests
+          python -m pytest --cov tests
 
   finish:
     needs:
@@ -115,7 +118,7 @@ jobs:
     steps:
       - name: Coveralls Finished
         run: |
-          pip install --upgrade coveralls
+          python -m pip install --upgrade coveralls
           coveralls --finish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,12 +13,15 @@ Bug Fixes
 * Remove encoding settings with regards to compression for string variables to avoid netCDF write errors with newer netcdf-c versions (>4.9.0) (#319).
 * Fixed a few docstrings, specifies some class methods as static methods (#321).
 * Renamed a few internal variables for clarity, rephrased a few sentences for grammar/spelling (#321).
+* Fixed a bug related to the creation of the `weights_dir` for regridding that was causing issues for Windows platforms (#313).
 
 Other Changes
 ^^^^^^^^^^^^^
 * The compression level is capped at 1 to reduce write times (#319).
 * Updated pre-commit hooks, pinned linting tools to their pre-commit equivalents (#321).
 * Added a pre-commit hook as well as a configuration for `codespell` (#321).
+* The `require_module` decorator can now accept supported version information (#321).
+* Testing data caching now uses platformdirs to determine the OS-appropriate caching location (#321).
 
 v0.12.2 (2024-01-03)
 --------------------

--- a/clisops/core/regrid.py
+++ b/clisops/core/regrid.py
@@ -19,7 +19,6 @@ import roocs_grids
 import xarray as xr
 from packaging.version import Version
 from roocs_utils.exceptions import InvalidParameterValue
-from xarray import __version__ as __xarray_version__
 
 import clisops.utils.dataset_utils as clidu
 from clisops import CONFIG
@@ -40,13 +39,12 @@ except (ModuleNotFoundError, ValueError):
 
 # FIXME: Remove this when xarray addresses https://github.com/pydata/xarray/issues/7794
 XARRAY_INCOMPATIBLE_VERSION = "2023.03.0"
-if Version(__xarray_version__) >= Version(XARRAY_INCOMPATIBLE_VERSION):
-    warnings.warn(
-        f"xarray version >= {XARRAY_INCOMPATIBLE_VERSION} "
-        f"is not supported for regridding operations with cf-time indexed arrays. "
-        f"Please use xarray version < {XARRAY_INCOMPATIBLE_VERSION}. "
-        "For more information, see: https://github.com/pydata/xarray/issues/7794."
-    )
+XARRAY_WARNING_MESSAGE = (
+    f"xarray version >= {XARRAY_INCOMPATIBLE_VERSION} "
+    f"is not supported for regridding operations with cf-time indexed arrays. "
+    f"Please use xarray version < {XARRAY_INCOMPATIBLE_VERSION}. "
+    "For more information, see: https://github.com/pydata/xarray/issues/7794."
+)
 
 
 # Read coordinate variable precision from the clisops configuration (roocs.ini)
@@ -56,6 +54,15 @@ coord_precision_hor = int(CONFIG["clisops:coordinate_precision"]["hor_coord_deci
 # Check if xESMF module is imported - decorator, used below
 require_xesmf = functools.partial(
     require_module, module=xe, module_name="xESMF", min_version=XESMF_MINIMUM_VERSION
+)
+
+# Check if xarray version is compatible - decorator, used below
+require_older_xarray = functools.partial(
+    require_module,
+    module=xr,
+    module_name="xarray",
+    max_supported_version=XARRAY_INCOMPATIBLE_VERSION,
+    max_supported_warning=XARRAY_WARNING_MESSAGE,
 )
 
 
@@ -82,8 +89,10 @@ def weights_cache_init(
         CONFIG["clisops:grid_weights"]["local_weights_dir"] = str(weights_dir)
     elif config["clisops:grid_weights"]["local_weights_dir"] == "":
         # Use platformdirs to determine the local weights cache directory
-        weights_dir = platformdirs.user_data_dir("clisops", "roocs")
-        CONFIG["clisops:grid_weights"]["local_weights_dir"] = weights_dir
+        weights_dir = (
+            Path(platformdirs.user_data_dir("clisops", "roocs")) / "grid_weights"
+        )
+        CONFIG["clisops:grid_weights"]["local_weights_dir"] = str(weights_dir)
     else:
         weights_dir = config["clisops:grid_weights"]["local_weights_dir"]
 
@@ -353,6 +362,7 @@ class Grid:
         self.format = self.detect_format()
 
     @require_xesmf
+    @require_older_xarray
     def _grid_from_instructor(self, grid_instructor: tuple | float | int):
         """Process instructions to create regional or global grid (uses xESMF utility functions)."""
         # Create tuple of length 1 if input is either float or int
@@ -383,6 +393,7 @@ class Grid:
         self.format = "xESMF"
 
     @require_xesmf
+    @require_older_xarray
     def _grid_from_ds_adaptive(self, ds: xr.Dataset | xr.DataArray):
         """Create Grid of similar extent and resolution of input dataset."""
         # TODO: dachar/daops to deal with missing values occurring in the coordinate variables
@@ -1424,6 +1435,7 @@ class Weights:
     """
 
     @require_xesmf
+    @require_older_xarray
     def __init__(
         self,
         grid_in: Grid,
@@ -1761,6 +1773,7 @@ class Weights:
 
 
 @require_xesmf
+@require_older_xarray
 def regrid(
     grid_in: Grid,
     grid_out: Grid,

--- a/clisops/core/regrid.py
+++ b/clisops/core/regrid.py
@@ -38,7 +38,7 @@ except (ModuleNotFoundError, ValueError):
     xe = None
 
 # FIXME: Remove this when xarray addresses https://github.com/pydata/xarray/issues/7794
-XARRAY_INCOMPATIBLE_VERSION = "2023.03.0"
+XARRAY_INCOMPATIBLE_VERSION = "2023.3.0"
 XARRAY_WARNING_MESSAGE = (
     f"xarray version >= {XARRAY_INCOMPATIBLE_VERSION} "
     f"is not supported for regridding operations with cf-time indexed arrays. "

--- a/clisops/etc/roocs.ini
+++ b/clisops/etc/roocs.ini
@@ -6,7 +6,7 @@ file_size_limit = 1GB
 output_staging_dir =
 
 [clisops:grid_weights]
-local_weights_dir = /tmp/clisops_grid_weights
+local_weights_dir =
 remote_weights_svc =
 
 [clisops:coordinate_precision]

--- a/clisops/utils/common.py
+++ b/clisops/utils/common.py
@@ -7,8 +7,7 @@ from types import FunctionType, ModuleType
 from typing import List, Optional, Union
 
 from loguru import logger
-
-# from roocs_utils.parameter import parameterise
+from packaging.version import Version
 
 
 def expand_wildcards(paths: Union[str, Path]) -> list:
@@ -30,12 +29,16 @@ def require_module(
 
     @functools.wraps(func)
     def wrapper_func(*args, **kwargs):
+        exception_msg = (
+            f"Package {module_name} >= {min_version} is required to use {func}."
+        )
         if module is None:
-            raise Exception(
-                f"Package {module_name} >= {min_version} is required to use {func}."
-            )
+            raise ModuleNotFoundError(exception_msg)
+        if Version(module.__version__) < Version(min_version):
+            raise ImportError(exception_msg)
+
         if max_supported_version is not None:
-            if module.__version__ > max_supported_version:
+            if Version(module.__version__) > Version(max_supported_version):
                 if max_supported_warning is not None:
                     warnings.warn(max_supported_warning)
                 else:

--- a/clisops/utils/common.py
+++ b/clisops/utils/common.py
@@ -1,6 +1,7 @@
 import functools
 import os
 import sys
+import warnings
 from pathlib import Path
 from types import FunctionType, ModuleType
 from typing import List, Optional, Union
@@ -22,6 +23,8 @@ def require_module(
     module: ModuleType,
     module_name: str,
     min_version: Optional[str] = "0.0.0",
+    max_supported_version: Optional[str] = None,
+    max_supported_warning: Optional[str] = None,
 ):
     """Ensure that module is installed before function/method is called, decorator."""
 
@@ -31,6 +34,15 @@ def require_module(
             raise Exception(
                 f"Package {module_name} >= {min_version} is required to use {func}."
             )
+        if max_supported_version is not None:
+            if module.__version__ > max_supported_version:
+                if max_supported_warning is not None:
+                    warnings.warn(max_supported_warning)
+                else:
+                    warnings.warn(
+                        f"Package {module_name} version {module.__version__} "
+                        f"is greater than the suggested version {max_supported_version}."
+                    )
         return func(*args, **kwargs)
 
     return wrapper_func

--- a/clisops/utils/tutorial.py
+++ b/clisops/utils/tutorial.py
@@ -9,12 +9,13 @@ from urllib.error import HTTPError
 from urllib.parse import urljoin
 from urllib.request import urlretrieve
 
+import platformdirs
 import requests
 from loguru import logger
 from xarray import Dataset
 from xarray import open_dataset as _open_dataset
 
-_default_cache_dir = Path.home() / ".clisops_testing_data"
+_default_cache_dir = Path(platformdirs.user_cache_dir("clisops", "roocs"))
 
 
 __all__ = ["get_file", "open_dataset", "query_folder"]

--- a/docs/notebooks/regrid.ipynb
+++ b/docs/notebooks/regrid.ipynb
@@ -821,7 +821,10 @@
    "source": [
     "### Local weights cache\n",
     "\n",
-    "Weights are cached on disk and do not have to be created more than once. The default cache directory is `/tmp/clisops_grid_weights` and should be adjusted either in the `roocs.ini` configuration file that can be found in the clisops installation directory or via:\n",
+    "Weights are cached on disk and do not have to be created more than once. The default cache directory is platform-dependent and set via the package `platformdirs`. For Linux it is `'/home/my_user/.local/share/clisops/weights_dir'` and can optionally be adjusted:\n",
+    "\n",
+    "- permanently by modifying the parameter `grid_weights: local_weights_dir` in the `roocs.ini` configuration file that can be found in the clisops installation directory\n",
+    "- or temporarily via:\n",
     "```python\n",
     "from clisops import core as clore\n",
     "clore.weights_cache_init(\"/dir/for/weights/cache\")\n",
@@ -835,7 +838,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ls -sh /tmp/clisops_grid_weights"
+    "from clisops.core.regrid import CONFIG\n",
+    "print(CONFIG[\"clisops:grid_weights\"][\"local_weights_dir\"])"
    ]
   },
   {
@@ -845,12 +849,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cat /tmp/clisops_grid_weights/weights_*_conservative.json"
+    "!ls -sh {CONFIG[\"clisops:grid_weights\"][\"local_weights_dir\"]}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat {CONFIG[\"clisops:grid_weights\"][\"local_weights_dir\"]}/weights_*_conservative.json"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "source": [
     "Now the weights will be read directly from the cache"
@@ -859,7 +873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -868,20 +882,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "source": [
     "The weights cache can be flushed, which removes all weight and grid files as well as the json files holding the metadata. To see what would be removed, one can use the `dryrun=True` parameter. To re-initialize the weights cache in a different directory, one can use the `weights_dir_init=\"/new/dir/for/weights/cache\"` parameter. Even when re-initializing the weights cache under a new path, using `clore.weights_cache_flush`, no directory is getting removed, only above listed files. When `dryrun` is not set, the files that are getting deleted can be displayed with `verbose=True`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "75",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "clore.weights_cache_flush(dryrun=True)"
    ]
   },
   {
@@ -891,12 +895,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "clore.weights_cache_flush(dryrun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "clore.weights_cache_flush(verbose=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "source": [
     "<a id='clisops.core.regrid'></a>\n",
@@ -929,7 +943,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -939,7 +953,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -948,7 +962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "#### Plot the resulting data"
@@ -957,7 +971,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -981,7 +995,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1011,7 +1025,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1025,7 +1039,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
  - roocs-grids >=0.1.2
  - roocs-utils >=0.6.7,<0.7
  - shapely >=1.9
- - xarray >=0.21,<2023.03.0 # See: https://github.com/pydata/xarray/issues/7794
+ - xarray >=0.21,<2023.3.0 # See: https://github.com/pydata/xarray/issues/7794
  - xesmf >=0.8.2
   # Dev tools and testing
  - black >=23.10.1

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
  - numpy >=1.16
  - packaging
  - pandas >=1.0.3
+ - platformdirs >=4.0
  - pooch
  - poppler >=0.67
  - pyproj >=3.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
   "numpy>=1.16",
   "packaging",
   "pandas>=1.0.3",
+  "platformdirs>=4.0",
   "pooch",
   "pyproj>=3.3.0",
   "requests>=2.0",

--- a/tests/test_core_regrid.py
+++ b/tests/test_core_regrid.py
@@ -1034,11 +1034,11 @@ def test_cache_lock_mechanism(load_esgf_test_data, tmp_path):
     with pytest.warns(UserWarning, match="lockfile") as issuedWarnings:
         Weights(grid_in=grid_in, grid_out=grid_out, method="nearest_s2d")
         if not issuedWarnings:
-            raise Exception("Lockfile not recognized/ignored.")
+            raise RuntimeError("Lockfile not recognized/ignored.")
         else:
+            for issuedWarning in issuedWarnings:
+                print(issuedWarning.message)
             assert len(issuedWarnings) == 1
-            # for issuedWarning in issuedWarnings:
-            #    print(issuedWarning.message)
 
     lock.release()
 
@@ -1141,6 +1141,8 @@ class TestRegrid:
                     "No warning issued regarding the duplicated cells in the grid."
                 )
             else:
+                for issuedWarning in issuedWarnings:
+                    print(issuedWarning.message)
                 assert len(issuedWarnings) == 1
 
     def test_regrid_dataarray(self, load_esgf_test_data, tmp_path):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #320 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->

* Uses `platformdirs` to set a default platform-dependent location in the event that one is not provided for `local_weights_dir`.
* `platformdirs` now handles the caching location for testing data.
* `require_module` now handles supported module version information.
* Fixed the version pinning and comparison code for xarray (`2023.03` → `2023.3`)

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->

Yes. The default location hard-set in the `roocs.ini` configuration has been removed.

Additionally, the `.clisops_testing_data` folder can be removed from your `$HOME` folder. This is now saved to `$HOME/.cache/clisops` on *nix.

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->

On Linux, this looks like: 
```python

from clisops.core.regrid import CONFIG

CONFIG["clisops:grid_weights"]["local_weights_dir"]
>>>'/home/my_user/.local/share/clisops/weights_dir'
```