### PR TITLE
Support Python3.12, various fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,8 @@ jobs:
             tox-env: py310
           - python-version: "3.11"
             tox-env: py311
+          - python-version: "3.12"
+            tox-env: py312
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,8 @@ jobs:
             upstream: false
           - python-version: "3.11"
             upstream: false
+          - python-version: "3.12"
+            upstream: false
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,8 +83,8 @@ jobs:
             upstream: false
           - python-version: "3.11"
             upstream: false
-          - python-version: "3.12"
-            upstream: false
+#          - python-version: "3.12"  # Not yet available until https://github.com/pydata/xarray/issues/7794 is resolved
+#            upstream: false
     defaults:
       run:
         shell: bash -l {0}
@@ -97,11 +97,9 @@ jobs:
           cache-environment: true
           environment-file: environment.yml
           create-args: >-
-            conda
             python=${{ matrix.python-version }}
       - name: Conda and Mamba versions
         run: |
-          conda --version
           echo "micromamba: $(micromamba --version)"
       - name: Install CLISOPS
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 concurrency:
   # For a given workflow, if we push to the same branch, cancel all previous builds on that branch except on master.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,14 @@ on:
       - master
   pull_request:
 
+concurrency:
+  # For a given workflow, if we push to the same branch, cancel all previous builds on that branch except on master.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Linting Suite
@@ -15,10 +23,6 @@ jobs:
         tox-env:
           - lint
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: toml-sort-fix
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: 24.2.0
     hooks:
     -   id: black
   - repo: https://github.com/pycqa/flake8
@@ -47,7 +47,7 @@ repos:
     rev: v0.3.9
     hooks:
       - id: blackdoc
-        additional_dependencies: [ 'black==24.1.1' ]
+        additional_dependencies: [ 'black==24.2.0' ]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ Version History
 v0.12.3 (unreleased)
 --------------------
 
+New Features
+^^^^^^^^^^^^
+* `clisops` now officially supports Python 3.12 (#330).
+
 Bug Fixes
 ^^^^^^^^^
 * Fixed standard file-namer fallback method (#318).
@@ -23,6 +27,10 @@ Other Changes
 * Added `dependabot` to maintain package and GitHub Action versions (#322).
 * The `require_module` decorator can now accept supported version information (#321).
 * Testing data caching now uses platformdirs to determine the OS-appropriate caching location (#321).
+* Updated `black` in linting tools to v24.2.0 (#330).
+* Changes some print calls into logging calls in the tests (#330).
+* A warning is now emitted on `clisops` import if the installed `xesmf` is too old (#330).
+* Replaced `styfle/cancel-workflow-action` with GitHub Workflow concurrency settings (#330).
 
 v0.12.2 (2024-01-03)
 --------------------

--- a/clisops/core/regrid.py
+++ b/clisops/core/regrid.py
@@ -33,6 +33,8 @@ try:
     import xesmf as xe
 
     if Version(xe.__version__) < Version(XESMF_MINIMUM_VERSION):
+        msg = f"xESMF >= {XESMF_MINIMUM_VERSION} is required to use the regridding operations."
+        warnings.warn(msg)
         raise ValueError()
 except (ModuleNotFoundError, ValueError):
     xe = None

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: clisops
 channels:
  - conda-forge
 dependencies:
- - python >=3.8,<3.12
+ - python >=3.8,<3.13
  - flit
  - bottleneck >=1.3.1
  - cf_xarray >=0.8.6

--- a/environment.yml
+++ b/environment.yml
@@ -26,8 +26,8 @@ dependencies:
  - xarray >=0.21,<2023.3.0 # See: https://github.com/pydata/xarray/issues/7794
  - xesmf >=0.8.2
   # Dev tools and testing
- - black >=23.10.1
- - bump-my-version
+ - black >=24.2.0
+ - bump-my-version >=0.17.1
  - flake8
  - gitpython >=3.1.30
  - ipython
@@ -36,7 +36,7 @@ dependencies:
  - pre-commit >=3.0.0
  - pytest
  - pytest-cov
- - pytest-loguru >=0.2.0
+ - pytest-loguru >=0.3.0
  - tox >=4.0
  - watchdog
  # Documentation

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
  - xarray >=0.21,<2023.3.0 # See: https://github.com/pydata/xarray/issues/7794
  - xesmf >=0.8.2
   # Dev tools and testing
- - black >=24.2.0
+ - black >=24.1.0
  - bump-my-version >=0.17.1
  - flake8
  - gitpython >=3.1.30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
   "flit",
   # Dev tools and testing
   "black>=24.2.0",
-  "bump-my-version>=0.1.2",
+  "bump-my-version>=0.17.1",
   "flake8",
   "gitpython>=3.1.30",
   "ipython",
@@ -83,7 +83,7 @@ dev = [
   "pre-commit>=3.0.0",
   "pytest",
   "pytest-cov",
-  "pytest-loguru>=0.2.0",
+  "pytest-loguru>=0.3.0",
   "tox>=4.0",
   "watchdog"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dev = [
   # Packaging
   "flit",
   # Dev tools and testing
-  "black>=23.11.0",
+  "black>=24.2.0",
   "bump-my-version>=0.1.2",
   "flake8",
   "gitpython>=3.1.30",
@@ -118,7 +118,8 @@ target-version = [
   "py38",
   "py39",
   "py310",
-  "py311"
+  "py311",
+  "py312"
 ]
 
 [tool.bumpversion]

--- a/tests/test_ops_regrid.py
+++ b/tests/test_ops_regrid.py
@@ -7,7 +7,9 @@ import pytest
 import xarray as xr
 from roocs_grids import get_grid_file, grid_dict
 
-from _common import (  # ATLAS_v1_CORDEX,; ATLAS_v1_EOBS_GRID,
+from _common import ATLAS_v1_CORDEX  # noqa
+from _common import ATLAS_v1_EOBS_GRID  # noqa
+from _common import (
     CMIP5_MRSOS_ONE_TIME_STEP,
     CMIP6_ATM_VERT_ONE_TIMESTEP,
     CMIP6_IITM_EXTENT,

--- a/tests/test_ops_regrid.py
+++ b/tests/test_ops_regrid.py
@@ -7,15 +7,15 @@ import pytest
 import xarray as xr
 from roocs_grids import get_grid_file, grid_dict
 
-from _common import ATLAS_v1_CORDEX  # noqa
-from _common import ATLAS_v1_EOBS_GRID  # noqa
-from _common import (
+from _common import (  # noqa
     CMIP5_MRSOS_ONE_TIME_STEP,
     CMIP6_ATM_VERT_ONE_TIMESTEP,
     CMIP6_IITM_EXTENT,
     CMIP6_OCE_HALO_CNRM,
     CMIP6_TOS_ONE_TIME_STEP,
     ATLAS_v0_CORDEX_ANT,
+    ATLAS_v1_CORDEX,
+    ATLAS_v1_EOBS_GRID,
     ContextLogger,
 )
 from clisops.core.regrid import XESMF_MINIMUM_VERSION, weights_cache_init, xe

--- a/tests/test_output_utils.py
+++ b/tests/test_output_utils.py
@@ -228,8 +228,8 @@ def test_tmp_dir_deleted(tmpdir):
 
 
 def test_unify_chunks_cmip5():
-    """
-    testing unify chunks with a cmip5 example:
+    """test unify chunks with a cmip5 example.
+
     da.unify_chunks() doesn't change da.chunks
     ds = ds.unify_chunks() doesn't appear to change ds.chunks in our case
     """
@@ -252,8 +252,8 @@ def test_unify_chunks_cmip5():
 
 
 def test_unify_chunks_cmip6():
-    """
-    testing unify chunks with a cmip6 example:
+    """Test unify chunks with a cmip6 example.
+
     da.unify_chunks() doesn't change da.chunks
     ds = ds.unify_chunks() doesn't appear to change ds.chunks in our case
     """

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 min_version = 4.0
 envlist =
-    py{38,39,310,311}
+    py{38,39,310,311,312}
     lint
     docs
 requires =
@@ -13,7 +13,7 @@ opts = -v
 skip_install = True
 basepython = python
 deps =
-    black >= 24.1.1
+    black >= 24.2.0
     flake8 >= 7.0.0
     isort >= 5.13.2
 commands_pre =


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->

* Adds builds and metadata suggesting support for Python3.12
* Update `black` to 24.2.0
* Changes some print calls into logging calls in the tests
* Now emits a warning on import if the installed `xesmf` is too old
* Replaced styfle/cancel-workflow-action with GitHub Workflow concurrency settings

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->

No.

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->

I'm going to prepare a new release based off this branch (v0.12.3)