### PR TITLE
Use loguru for warnings reporting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Version History
 ===============
 
+v0.13.1 (unreleased)
+--------------------
+
+Other Changes
+^^^^^^^^^^^^^
+* Internal warnings now consistently use the `clisops` configured `loguru` logger (#335).
+
 v0.13.0 (2024-02-16)
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  # "Programming Language :: Python :: 3.12",  # Not yet available until https://github.com/pydata/xarray/issues/7794 is resolved
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Atmospheric Science",
   "Topic :: Scientific/Engineering :: GIS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,27 +46,27 @@ classifiers = [
 ]
 dynamic = ["description", "version"]
 dependencies = [
-  "bottleneck>=1.3.1",
+  "bottleneck >=1.3.1",
   # cf-xarray is differently named on conda-forge
-  "cf-xarray>=0.8.6;python_version>='3.9'",
-  "cf-xarray>=0.7.5,<=0.8.0;python_version=='3.8'",
-  "cftime>=1.4.1",
-  "dask[complete]>=2.6",
-  "geopandas>=0.11",
-  "loguru>=0.5.3",
-  "netCDF4>=1.4",
-  "numpy>=1.16",
+  "cf-xarray >=0.8.6;python_version>='3.9'",
+  "cf-xarray >=0.7.5,<=0.8.0;python_version=='3.8'",
+  "cftime >=1.4.1",
+  "dask[complete] >=2.6",
+  "geopandas >=0.11",
+  "loguru >=0.5.3",
+  "netCDF4 >=1.4",
+  "numpy >=1.16",
   "packaging",
-  "pandas>=1.0.3",
-  "platformdirs>=4.0",
+  "pandas >=1.0.3",
+  "platformdirs >=4.0",
   "pooch",
-  "pyproj>=3.3.0",
-  "requests>=2.0",
+  "pyproj >=3.3.0",
+  "requests >=2.0",
   # roocs_grids is differently named on conda-forge
-  "roocs_grids>=0.1.2",
-  "roocs-utils>=0.6.7,<0.7",
-  "shapely>=1.9",
-  "xarray>=0.21"
+  "roocs_grids >=0.1.2",
+  "roocs-utils >=0.6.7,<0.7",
+  "shapely >=1.9",
+  "xarray >=0.21"
 ]
 
 [project.optional-dependencies]
@@ -74,18 +74,18 @@ dev = [
   # Packaging
   "flit",
   # Dev tools and testing
-  "black>=24.2.0",
-  "bump-my-version>=0.17.1",
+  "black >=24.2.0",
+  "bump-my-version >=0.18.3",
   "flake8",
-  "gitpython>=3.1.30",
+  "gitpython >=3.1.30",
   "ipython",
   "isort",
-  "jinja2>=2.11",
-  "pre-commit>=3.0.0",
+  "jinja2 >=2.11",
+  "pre-commit >=3.0.0",
   "pytest",
   "pytest-cov",
-  "pytest-loguru>=0.3.0",
-  "tox>=4.0",
+  "pytest-loguru >=0.3.0",
+  "tox>=4.5",
   "watchdog"
 ]
 docs = [
@@ -97,12 +97,12 @@ docs = [
   "nbconvert",
   "nbsphinx",
   "sphinx",
-  "sphinx-rtd-theme>=1.0"
+  "sphinx-rtd-theme >=1.0"
 ]
 extra = [
-  "xesmf>=0.8.2",
+  "xesmf >=0.8.2",
   # See: https://github.com/pydata/xarray/issues/7794
-  "xarray>=0.21.0,<2023.03.0"
+  "xarray >=0.21.0,<2023.03.0"
 ]
 
 [project.urls]

--- a/tests/test_core_subset.py
+++ b/tests/test_core_subset.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import geopandas as gpd
 import numpy as np
@@ -40,7 +41,7 @@ class TestSubsetTime:
         yr_st = "1776"
         yr_ed = "2077"
 
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_time(
                 da, start_date=f"{yr_st}-01", end_date=f"{yr_ed}-01"
             )
@@ -65,7 +66,7 @@ class TestSubsetTime:
         with pytest.raises(TypeError):
             subset.subset_time(da, start_yr=2050, end_yr=2059)
 
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             subset.subset_time(
                 da,
                 start_date=2050,  # noqa
@@ -76,7 +77,7 @@ class TestSubsetTime:
             in [str(q.message) for q in record]
         )
 
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             subset.subset_time(
                 da, start_date="2064-01-01T00:00:00", end_date="2065-02-01T03:12:01"
             )
@@ -96,20 +97,25 @@ class TestSubsetTime:
         yr_st = "2050"
 
         # start date only
-        with pytest.warns(None):  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_time(da, start_date=f"{yr_st}-01")
+        assert not record
+
         np.testing.assert_array_equal(out.time.dt.year.min(), int(yr_st))
         np.testing.assert_array_equal(out.time.dt.year.max(), da.time.dt.year.max())
 
-        with pytest.warns(None):  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_time(da, start_date=f"{yr_st}-07")
+        assert not record
+
         np.testing.assert_array_equal(out.time.dt.year.min(), int(yr_st))
         np.testing.assert_array_equal(out.time.min().dt.month, 7)
         np.testing.assert_array_equal(out.time.dt.year.max(), da.time.dt.year.max())
         np.testing.assert_array_equal(out.time.max(), da.time.max())
 
-        with pytest.warns(None):  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_time(da, start_date=f"{yr_st}-07-15")
+        assert not record
         np.testing.assert_array_equal(out.time.dt.year.min(), int(yr_st))
         np.testing.assert_array_equal(out.time.min().dt.month, 7)
         np.testing.assert_array_equal(out.time.min().dt.day, 15)
@@ -121,15 +127,19 @@ class TestSubsetTime:
         yr_ed = "2059"
 
         # end date only
-        with pytest.warns(None):  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_time(da, end_date=f"{yr_ed}-01")
+        assert not record
+
         np.testing.assert_array_equal(out.time.dt.year.max(), int(yr_ed))
         np.testing.assert_array_equal(out.time.max().dt.month, 1)
         np.testing.assert_array_equal(out.time.max().dt.day, 31)
         np.testing.assert_array_equal(out.time.min(), da.time.min())
 
-        with pytest.warns(None):  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_time(da, end_date=f"{yr_ed}-06-15")
+        assert not record
+
         np.testing.assert_array_equal(out.time.dt.year.max(), int(yr_ed))
         np.testing.assert_array_equal(out.time.max().dt.month, 6)
         np.testing.assert_array_equal(out.time.max().dt.day, 15)
@@ -625,7 +635,7 @@ class TestSubsetBbox:
             subset.subset_bbox(
                 da, lon_bnds=self.lon, lat_bnds=self.lat, start_yr=2050, end_yr=2059
             )
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             subset.subset_bbox(
                 da,
                 lon_bnds=self.lon,
@@ -725,7 +735,7 @@ class TestSubsetShape:
     def test_no_wraps(self, tmp_netcdf_filename):
         ds = xr.open_dataset(self.nc_file)
 
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             sub = subset.subset_shape(ds, self.poslons_geojson)
 
         self.compare_vals(ds, sub, "tas")
@@ -756,7 +766,7 @@ class TestSubsetShape:
     def test_all_neglons(self):
         ds = xr.open_dataset(self.nc_file_neglons)
 
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             sub = subset.subset_shape(ds, self.southern_qc_geojson)
 
         self.compare_vals(ds, sub, "tasmax")
@@ -775,7 +785,7 @@ class TestSubsetShape:
     def test_rotated_pole_with_time(self):
         ds = xr.open_dataset(self.lons_2d_nc_file)
 
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             sub = subset.subset_shape(
                 ds,
                 self.eastern_canada_geojson,
@@ -958,7 +968,7 @@ class TestSubsetLevel:
         lev_st = 10000000
         lev_ed = 10
 
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_level(da, first_level=lev_st, last_level=lev_ed)
 
         np.testing.assert_array_equal(out.plev.min(), da.plev.min())
@@ -979,14 +989,14 @@ class TestSubsetLevel:
         with pytest.raises(TypeError):
             subset.subset_level(da, first_level=da, last_level=da)
 
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             subset.subset_level(da, first_level="1000", last_level="1000")
         assert (
             '"first_level" should be a number, it has been converted to a float.'
             in [str(q.message) for q in record]
         )
 
-        with pytest.warns(None) as record:  # noqa
+        with warnings.catch_warnings(record=True) as record:
             subset.subset_level(da, first_level=81200, last_level=54100.6)
 
         msgs = {
@@ -1000,8 +1010,9 @@ class TestSubsetLevel:
         lev_st = 100000
 
         # first level only
-        with pytest.warns(None):  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_level(da, first_level=lev_st, last_level=lev_st)
+        assert not record
 
         np.testing.assert_array_equal(out.plev.values[0], da.plev.values[0])
         np.testing.assert_array_equal(out.plev.values[-1], da.plev.values[0])
@@ -1011,14 +1022,16 @@ class TestSubsetLevel:
         # good_levels = [40000, 30000]
         # good_indices = [6, 7]
 
-        with pytest.warns(None):  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_level(da, first_level=37000.2342, last_level=27777)
+        assert not record
 
         np.testing.assert_array_equal(out.plev.values[0], da.plev.values[7])
         np.testing.assert_array_equal(out.plev.values[-1], da.plev.values[7])
 
-        with pytest.warns(None):  # noqa
+        with warnings.catch_warnings(record=True) as record:
             out = subset.subset_level(da, first_level=41562, last_level=29999)
+        assert not record
 
         np.testing.assert_array_equal(out.plev.values[:], da.plev.values[6:8])
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->

* Updates the way that warnings are caught in `pytest` to use `loguru` consistently.

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->

Somewhat. `loguru` should always be used for warnings control everywhere, and this PR puts that into effect.

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->

Python3.12 support is still blocked due to https://github.com/pydata/xarray/issues/7794. Not sure if there's anything we can do about that.