### PR TITLE
Subset without masking - accept shapely polygons

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@ Version History
 v0.13.1 (unreleased)
 --------------------
 
+New Features
+^^^^^^^^^^^^
+* Core bbox and shape subsetting accepts a ``mask_outside`` argument. When False, data outside the shape/box but within the subsetted dataset is not masked (#337).
+* Added ``shapely.Polygon`` to the types understood by ``core.subset.subset_shape`` (#337).
+
 Other Changes
 ^^^^^^^^^^^^^
 * Internal warnings now consistently use the `clisops` configured `loguru` logger (#335).


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->
Two new features:
 - `mask_outside` argument added to `core.subset.subset_shape` and `core.subset.subset_bbox`. When False, the data that is outside the box/shape, but within the subset itself is not masked. Of course, this only really changes anything when the grid is not a lat-lon grid.
 - `core.subset.subset_shape` can now accept `shapely.Polygon` object as its `shape` argument.

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->
No. The default value of the new argument is True, which retains the previous behaviour.

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->
