### PR TITLE
Better manage shape_crs and raster_crs in subset_shape

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,3 +23,4 @@ Contributors
 * Martin Schupfner <schupfner@dkrz.de> `@sol1105 <https://github.com/sol1105>`_
 * Marco Braun <Braun.Marco@ouranos.ca> `@vindelico <https://github.com/vindelico>`_
 * Charles Gauthier <gauthier.charles@ouranos.ca> `@charlesgauthier-udm <https://github.com/charlesgauthier-udm>`_
+* Gabriel Rondeau-Genesse <rondeau-genesse.gabriel@ouranos.ca> `@RondeauG <https://github.com/RondeauG>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ Version History
 v0.13.1 (unreleased)
 --------------------
 
+Bug Fixes
+^^^^^^^^^
+* Changed the order of operations in `clisops.core.subset.subset_shape` to ensure that the CRS of the shapefile is compatible with the dataset CRS before attempting to subset (#340).
+
 Other Changes
 ^^^^^^^^^^^^^
 * Internal warnings now consistently use the `clisops` configured `loguru` logger (#335).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Bug Fixes
 ^^^^^^^^^
 * Changed the order of operations in `clisops.core.subset.subset_shape` to ensure that the CRS of the shapefile is compatible with the dataset CRS before attempting to subset (#340).
 
+Breaking Changes
+^^^^^^^^^^^^^^^^
+* Anaconda builds now require `cartopy >=0.23` and only support Python 3.9 and above (#340).
+
 Other Changes
 ^^^^^^^^^^^^^
 * Internal warnings now consistently use the `clisops` configured `loguru` logger (#335).

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1049,7 +1049,7 @@ def subset_shape(
         wrap = False
         if rcrs is not None:
             try:
-                r = CRS.from_user_input(rcrs)
+                rcrs = CRS.from_user_input(rcrs)
             except ValueError:
                 raise
         else:

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
  - python >=3.8,<3.13
  - flit
  - bottleneck >=1.3.1
- - cartopy >=0.23
+ - cartopy >=0.23.0
  - cf_xarray >=0.8.6
  - cftime >=1.4.1
  - dask >=2.6.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
  - python >=3.8,<3.13
  - flit
  - bottleneck >=1.3.1
+ - cartopy >=0.23
  - cf_xarray >=0.8.6
  - cftime >=1.4.1
  - dask >=2.6.0
@@ -12,7 +13,7 @@ dependencies:
  - geopandas >=0.11
  - loguru >=0.5.3
  - netCDF4 >=1.4
- - numpy >=1.16
+ - numpy >=1.16,<2.1
  - packaging
  - pandas >=1.0.3
  - platformdirs >=4.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: clisops
 channels:
  - conda-forge
 dependencies:
- - python >=3.8,<3.13
+ - python >=3.9,<3.13
  - flit
  - bottleneck >=1.3.1
  - cartopy >=0.23.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dynamic = ["description", "version"]
 dependencies = [
   "bottleneck >=1.3.1",
   # cf-xarray is differently named on conda-forge
-  "cartopy; python_version=='3.8'",
   "cartopy >=0.23; python_version>='3.9'",
   "cf-xarray >=0.8.6; python_version>='3.9'",
   "cf-xarray >=0.7.5,<=0.8.0; python_version=='3.8'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,10 @@ dynamic = ["description", "version"]
 dependencies = [
   "bottleneck >=1.3.1",
   # cf-xarray is differently named on conda-forge
-  "cartopy <0.23; python_version=='3.8",
+  "cartopy; python_version=='3.8'",
   "cartopy >=0.23; python_version>='3.9'",
-  "cf-xarray >=0.8.6;python_version>='3.9'",
-  "cf-xarray >=0.7.5,<=0.8.0;python_version=='3.8'",
+  "cf-xarray >=0.8.6; python_version>='3.9'",
+  "cf-xarray >=0.7.5,<=0.8.0; python_version=='3.8'",
   "cftime >=1.4.1",
   "dask[complete] >=2.6",
   "geopandas >=0.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ dynamic = ["description", "version"]
 dependencies = [
   "bottleneck >=1.3.1",
   # cf-xarray is differently named on conda-forge
-  "cartopy >=0.23.0",
+  "cartopy <0.23; python_version=='3.8",
+  "cartopy >=0.23; python_version>='3.9'",
   "cf-xarray >=0.8.6;python_version>='3.9'",
   "cf-xarray >=0.7.5,<=0.8.0;python_version=='3.8'",
   "cftime >=1.4.1",
@@ -56,7 +57,8 @@ dependencies = [
   "geopandas >=0.11",
   "loguru >=0.5.3",
   "netCDF4 >=1.4",
-  "numpy >=1.16,<2.1",
+  "numpy >=1.16; python_version=='3.8'",
+  "numpy >=1.16,<2.1; python_version>='3.9'",
   "packaging",
   "pandas >=1.0.3",
   "platformdirs >=4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dynamic = ["description", "version"]
 dependencies = [
   "bottleneck >=1.3.1",
   # cf-xarray is differently named on conda-forge
-  "cartopy >=0.23",
+  "cartopy >=0.23.0",
   "cf-xarray >=0.8.6;python_version>='3.9'",
   "cf-xarray >=0.7.5,<=0.8.0;python_version=='3.8'",
   "cftime >=1.4.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dynamic = ["description", "version"]
 dependencies = [
   "bottleneck >=1.3.1",
   # cf-xarray is differently named on conda-forge
+  "cartopy >=0.23",
   "cf-xarray >=0.8.6;python_version>='3.9'",
   "cf-xarray >=0.7.5,<=0.8.0;python_version=='3.8'",
   "cftime >=1.4.1",
@@ -55,7 +56,7 @@ dependencies = [
   "geopandas >=0.11",
   "loguru >=0.5.3",
   "netCDF4 >=1.4",
-  "numpy >=1.16",
+  "numpy >=1.16,<2.1",
   "packaging",
   "pandas >=1.0.3",
   "platformdirs >=4.0",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->

* Fixes bugs in `subset_shape`:
  * Changes the order of the checks in `subset_shape` to check that the CRS are compatible at the start of the function, instead of after `subset_bbox`.
  * `poly` is reprojected to WGS84. This ensures that both `lon/lat_bnds` (for `subset_bbox`) and `mask_2d` are computed with compatible units and projections.

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->


### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->
