### PR TITLE
drop Python3.9, fix tox configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python${{ matrix.python-version }}
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          python-version: "3.10"
+          python-version: "3.x"
           cache: pip
       - name: Install CI libraries
         run: |
@@ -96,7 +96,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('pyproject.toml', 'tox.ini') }}-Python${{ matrix.python-version }}-${{ env.ESGF_TEST_DATA_VERSION }}
       - name: Test with tox
         run: |
-          python -m tox
+          python -m tox -e py${{ matrix.python-version }}${{ (matrix.python-version == '3.13') && '' || '-coveralls' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: run-Python${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('pyproject.toml', 'tox.ini') }}-Python${{ matrix.python-version }}-${{ env.ESGF_TEST_DATA_VERSION }}
       - name: Test with tox
         run: |
-          python -m tox -e py${{ matrix.python-version }}${{ (matrix.python-version == '3.13') && '' || '-coveralls' }}
+          python -m tox
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: run-Python${{ matrix.python-version }}

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: clisops
 channels:
  - conda-forge
 dependencies:
- - python >=3.9,<3.14
+ - python >=3.10,<3.14
  - flit >=3.10.1,<4.0
  - pip >=25.0
  - aiohttp # Needed for HTTPFileSystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
   {name = "Trevor James Smith", email = "smith.trevorj@ouranos.ca"}
 ]
 readme = {file = "README.rst", content-type = "text/x-rst"}
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 keywords = ["clisops", "xarray", "climate", "gis", "subsetting", "operations"]
 license = {file = "LICENSE"}
 classifiers = [
@@ -29,7 +29,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12", # Compatibility issues will persist until https://github.com/pydata/xarray/issues/7794 is resolved

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 min_version = 4.24.1
 envlist =
-    py{39,310,311,312,313}
+    py{3.10,3.11,3.12,3.13}
     lint
     docs
 requires =
@@ -11,11 +11,10 @@ opts = -v
 
 [gh]
 python =
-    3.9 = py39-coveralls
-    3.10 = py312-coveralls
-    3.11 = py311-coveralls
-    3.12 = py312-coveralls
-    3.13 = py313
+    3.10 = py3.10-coveralls
+    3.11 = py3.11-coveralls
+    3.12 = py3.12-coveralls
+    3.13 = py3.13
 
 [testenv:lint]
 skip_install = True


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->

* Drop Python3.9 support, as the latest xarray doesn't support it.
* Fixes an issue in the `tox.ini` that was using the wrong version of Python when running tests on Python 3.10

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->

Sort of. Python3.9 was not supported by `xarray` v2025.1.1 already.

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->

I'll be yanking the last `clisops` release and releasing a v0.16.1 to address this issue. The changelog will be updated here.