### PR TITLE
Regrid updates and output fixes

### DIFF
--- a/clisops/utils/common.py
+++ b/clisops/utils/common.py
@@ -85,6 +85,7 @@ def require_module(
     module: ModuleType,
     module_name: str,
     min_version: str | None = "0.0.0",
+    unsupported_version_range: list | None = None,
     max_supported_version: str | None = None,
     max_supported_warning: str | None = None,
 ) -> Callable:
@@ -101,6 +102,13 @@ def require_module(
         The name of the module to check.
     min_version : str, optional
         The minimum version of the module required. Defaults to "0.0.0".
+    unsupported_version_range : list of str, optional
+        A list with two elements, with the elements marking a range of unsupported versions,
+        with the first element being the first unsupported and the second element being
+        the first supported version.
+        If provided, a warning will be issued if the module version falls within this range:
+        version_0 <= module_version < version_1
+        Defaults to None, meaning no unsupported version range check is performed.
     max_supported_version : str, optional
         The maximum supported version of the module.
         If provided, a warning will be issued if the module version exceeds this.
@@ -131,6 +139,18 @@ def require_module(
                         f"Package {module_name} version {module.__version__} "
                         f"is greater than the suggested version {max_supported_version}."
                     )
+
+        if unsupported_version_range is not None:
+            if not isinstance(unsupported_version_range, list) or not len(unsupported_version_range) == 2:
+                raise ValueError(
+                    "The unsupported_version_range argument must be a list with two elements of type str, "
+                    "with the elements being the minimum and maximum versions of an unsupported version range."
+                )
+            if Version(module.__version__) >= Version(unsupported_version_range[0]) and Version(
+                module.__version__
+            ) < Version(unsupported_version_range[1]):
+                warnings.warn(max_supported_warning)
+
         return func(*args, **kwargs)
 
     return wrapper_func

--- a/clisops/utils/dataset_utils.py
+++ b/clisops/utils/dataset_utils.py
@@ -22,7 +22,11 @@ KERCHUNK_EXTS = [".json", ".zst", ".zstd", ".parquet"]
 
 
 def get_coord_by_type(
-    ds: xr.DataArray | xr.Dataset, coord_type: str, ignore_aux_coords: bool = True, return_further_matches: bool = False
+    ds: xr.DataArray | xr.Dataset,
+    coord_type: str,
+    ignore_aux_coords: bool = True,
+    return_further_matches: bool = False,
+    warn_if_no_main_variable: bool = True,
 ):
     """
     Return the name of the coordinate that matches the given type.
@@ -34,9 +38,11 @@ def get_coord_by_type(
     coord_type : str
         Type of coordinate, e.g. 'time', 'level', 'latitude', 'longitude', 'realization'.
     ignore_aux_coords : bool
-        Whether to ignore auxiliary coordinates.
+        Whether to ignore auxiliary coordinates. Default is True.
     return_further_matches : bool
-        Whether to return further matches.
+        Whether to return further matches. Default is False.
+    warn_if_no_main_variable : bool
+        Whether to warn if no main variable can be identified. Default is True.
 
     Returns
     -------
@@ -62,7 +68,8 @@ def get_coord_by_type(
     try:
         main_var = get_main_variable(ds)
     except ValueError:
-        warnings.warn(f"No main variable found for dataset '{ds}'.")
+        if warn_if_no_main_variable:
+            warnings.warn(f"No main variable found for dataset '{ds}'.")
         main_var = None
 
     # Loop through all (potential) coordinates to find all possible matches

--- a/docs/notebooks/regrid.ipynb
+++ b/docs/notebooks/regrid.ipynb
@@ -32,8 +32,8 @@
     "import cf_xarray as cfxr\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import psyplot.project as psy\n",
     "import xarray as xr\n",
+    "from matplotlib.collections import PolyCollection\n",
     "\n",
     "os.environ[\"ESMFMKFILE\"] = str(Path(os.__file__).parent.parent / \"esmf.mk\")\n",
     "import xesmf as xe\n",
@@ -62,7 +62,7 @@
     "import clisops.utils.testing as clite\n",
     "\n",
     "Stratus = clite.stratus(\n",
-    "    repo=clite.XCLIM_TEST_DATA_REPO_URL, branch=clite.XCLIM_TEST_DATA_VERSION, cache_dir=clite.XCLIM_TEST_DATA_CACHE_DIR\n",
+    "    repo=clite.ESGF_TEST_DATA_REPO_URL, branch=clite.ESGF_TEST_DATA_VERSION, cache_dir=clite.ESGF_TEST_DATA_CACHE_DIR\n",
     ")\n",
     "\n",
     "mini_esgf_data = (\n",
@@ -362,7 +362,19 @@
    "source": [
     "#### Plot source data and remapped data\n",
     "\n",
-    "(Using [psyplot](https://psyplot.github.io/) to plot the unstructured data since xarray does not (yet?) support it.)"
+    "Below we use matplotlib to plot the data on the unstructured ICON-Grid, which requires some processing of the cell bounds. Using [psyplot](https://psyplot.github.io/) to plot the unstructured data is a simpler alternative. `psyplot` / `psymaps` is however not included in the `clisops` dependencies as it comes with complex dependencies itself.\n",
+    "\n",
+    "```python\n",
+    "# Source data - psyplot\n",
+    "ds_icono_path = ds_icono.encoding[\"source\"]\n",
+    "maps = psy.plot.mapplot(\n",
+    "    ds_icono_path,\n",
+    "    cmap=\"RdBu_r\",\n",
+    "    title=\"Source - ICON-ESM-LR ICON-O (Ruby-0, 40km resolution)\",\n",
+    "    time=[0],\n",
+    "    lev=[0]\n",
+    ")\n",
+    "```"
    ]
   },
   {
@@ -373,16 +385,69 @@
    "outputs": [],
    "source": [
     "# Source data\n",
-    "ds_icono_path = ds_icono.encoding[\"source\"]\n",
-    "maps = psy.plot.mapplot(\n",
-    "    ds_icono_path, cmap=\"RdBu_r\", title=\"Source - ICON-ESM-LR ICON-O (Ruby-0, 40km resolution)\", time=[0], lev=[0]\n",
-    ")"
+    "\n",
+    "# Function to fix cell_bounds crossing the meridian\n",
+    "#   to avoid horizontal lines in the plot\n",
+    "def fix_meridian_crossing(lon_bnds, lat_bnds):\n",
+    "    \"\"\"Shift longitudes from -180,180 to 0,360.\"\"\"\n",
+    "    fixed_lon = []\n",
+    "    fixed_lat = []\n",
+    "    for lon, lat in zip(lon_bnds, lat_bnds, strict=False):\n",
+    "        lon = np.array(lon)\n",
+    "        lat = np.array(lat)\n",
+    "        lon_range = lon.max() - lon.min()\n",
+    "        if lon_range > 180:  # crosses meridian\n",
+    "            # Shift longitudes < 180 by +360\n",
+    "            lon_corrected = np.where(lon < 180, lon + 360, lon)\n",
+    "        else:\n",
+    "            lon_corrected = lon\n",
+    "        fixed_lon.append(lon_corrected)\n",
+    "        fixed_lat.append(lat)\n",
+    "    return np.array(fixed_lon), np.array(fixed_lat)\n",
+    "\n",
+    "\n",
+    "fixed_lon, fixed_lat = fix_meridian_crossing(ds_icono.longitude_bnds.values, ds_icono.latitude_bnds.values)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Source data\n",
+    "fig, ax = plt.subplots(subplot_kw={\"projection\": ccrs.PlateCarree()}, figsize=(10, 6))\n",
+    "\n",
+    "# Plot as collection of polygons\n",
+    "pc = PolyCollection(\n",
+    "    [list(zip(*lonlat, strict=False)) for lonlat in zip(fixed_lon, fixed_lat, strict=False)],\n",
+    "    array=ds_icono[\"thetao\"].isel(time=0, lev=0).values.squeeze(),\n",
+    "    cmap=\"RdBu_r\",\n",
+    "    edgecolor=\"face\",\n",
+    "    transform=ccrs.PlateCarree(),\n",
+    ")\n",
+    "ax.add_collection(pc)\n",
+    "\n",
+    "# Adjust colorbar, title, labels and ticks\n",
+    "xticks = range(-180, 181, 60)\n",
+    "yticks = range(-90, 91, 30)\n",
+    "ax.set_xticks(xticks, crs=ccrs.PlateCarree())\n",
+    "ax.set_yticks(yticks, crs=ccrs.PlateCarree())\n",
+    "ax.set_xlabel(\"Longitude\", fontsize=12)\n",
+    "ax.set_ylabel(\"Latitude\", fontsize=12)\n",
+    "ax.autoscale()\n",
+    "ax.coastlines(resolution=\"10m\")\n",
+    "fig.colorbar(pc, ax=ax, label=\"thetao\", shrink=0.6)\n",
+    "fig.suptitle(\"Source - ICON-ESM-LR ICON-O (Ruby-0, 40km resolution)\", fontsize=14, x=0.45, y=0.8)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "<a id='clisops.core.Grid'></a>\n",
@@ -408,7 +473,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Create a grid object from an `xarray.Dataset`\n",
@@ -419,7 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "#### Create the Grid object"
@@ -438,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "The `xarray.Dataset` is attached to the `clisops.core.Grid` object. Auxiliary coordinates and data variables have been (re)set appropriately."
@@ -457,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +531,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "#### Plot the data"
@@ -475,7 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "### Create a grid object from an `xarray.DataArray`\n",
@@ -502,7 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -512,7 +577,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "#### Create Grid object for MPIOM tos dataarray:"
@@ -521,7 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,7 +596,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "### Create a grid object using a `grid_instructor`\n",
@@ -543,7 +608,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -564,7 +629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "### Create a grid object using a `grid_id`\n",
@@ -575,7 +640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +661,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### `clisops.core.Grid` objects can be compared to one another\n",
@@ -609,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -619,7 +684,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "#### Compare both 0.25° ERA5 Grids"
@@ -628,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +704,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,7 +715,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "### Strip `clisops.core.Grid` objects of all `data_vars` and `coords` unrelated to the horizontal grid"
@@ -659,7 +724,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +733,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "The parameter `keep_attrs` can be set, the default is `False`."
@@ -677,7 +742,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -687,7 +752,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "### Transfer coordinate variables between `clisops.core.Grid` objects that are unrelated to the horizontal grid\n",
@@ -700,7 +765,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +775,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "source": [
     "#### Create grid object"
@@ -719,7 +784,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,7 +794,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "#### Transfer the coordinates to the ERA5 grid object"
@@ -738,7 +803,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +813,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "source": [
     "<a id='clisops.core.Weights'></a>\n",
@@ -764,7 +829,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "### Create 2-degree target grid"
@@ -773,7 +838,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +848,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "### Create conservative remapping weights using the `clisops.core.Weights` class\n",
@@ -793,7 +858,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -802,7 +867,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "### Local weights cache\n",
@@ -820,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,7 +897,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -842,7 +907,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -851,7 +916,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "source": [
     "Now the weights will be read directly from the cache"
@@ -860,7 +925,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -869,20 +934,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "source": [
     "The weights cache can be flushed, which removes all weight and grid files as well as the json files holding the metadata. To see what would be removed, one can use the `dryrun=True` parameter. To re-initialize the weights cache in a different directory, one can use the `weights_dir_init=\"/new/dir/for/weights/cache\"` parameter. Even when re-initializing the weights cache under a new path, using `clore.weights_cache_flush`, no directory is getting removed, only above listed files. When `dryrun` is not set, the files that are getting deleted can be displayed with `verbose=True`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "76",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "clore.weights_cache_flush(dryrun=True)"
    ]
   },
   {
@@ -892,12 +947,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "clore.weights_cache_flush(dryrun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "clore.weights_cache_flush(verbose=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "source": [
     "<a id='clisops.core.regrid'></a>\n",
@@ -930,7 +995,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -940,7 +1005,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -949,7 +1014,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "source": [
     "#### Plot the resulting data"
@@ -958,7 +1023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -985,7 +1050,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1033,7 +1098,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
  # Compression
  - zstandard
  # Extras
- - xesmf >=0.8.10
+# - xesmf >=0.8.11 # until PR444 is merged and a release triggered, install from source branch for testing
 #  # Dev tools and testing
  - bump-my-version >=1.2.0
  - coverage >=7.5.0
@@ -58,9 +58,10 @@ dependencies:
  - matplotlib-base >=3.6.0
  - nbconvert >=7.14.0
  - nbsphinx >=0.9.5
- # - psy-maps >=1.5.0  # FIXME: This library is unmaintained and not available on conda-forge for Python 3.13
  - sphinx >=7.1.0,<8.2.0 # pinned until nbsphinx supports sphinx 8.2
  - sphinx-autodoc-typehints
  - sphinx-codeautolink
  - sphinx-copybutton
  - sphinx-rtd-theme >=1.0
+ - pip:
+   - git+https://github.com/sol1105/xESMF.git@domain_mask_nearest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ docs = [
   "matplotlib >=3.6.0",
   "nbconvert >=7.14.0",
   "nbsphinx >=0.9.5",
-  "psy-maps >=1.5.0", # FIXME: This library is unmaintained and not available on conda-forge for Python 3.13
   "sphinx >=7.1.0,<8.2", # pinned until nbsphinx supports sphinx 8.2
   "sphinx-autodoc-typehints",
   "sphinx-codeautolink",

--- a/tests/test_core_regrid.py
+++ b/tests/test_core_regrid.py
@@ -12,6 +12,8 @@ from roocs_grids import get_grid_file
 import clisops.utils.dataset_utils as clidu
 from clisops import CONFIG
 from clisops.core.regrid import (
+    XARRAY_COMPATIBLE_VERSION,
+    XARRAY_INCOMPATIBLE_VERSION,
     XESMF_MINIMUM_VERSION,
     Grid,
     Weights,
@@ -55,6 +57,7 @@ def test_grid_init_ds_tas_regular(mini_esgf_data):
         assert grid.lon == ds.lon.name
         assert grid.type == "regular_lat_lon"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
         assert not grid.contains_collapsed_cells
         assert not grid.contains_duplicated_cells
         assert grid.lat_bnds == ds.lat_bnds.name
@@ -80,6 +83,7 @@ def test_grid_init_ds_simass_degenerated_cells(mini_esgf_data):
         assert grid.lon == "longitude"
         assert grid.type == "curvilinear"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
         assert grid.contains_collapsed_cells
         assert grid.contains_smashed_cells
         assert grid.contains_duplicated_cells is False
@@ -107,6 +111,7 @@ def test_grid_init_ds_tos_degenerated_cells(mini_esgf_data):
         assert grid.lon == "longitude"
         assert grid.type == "curvilinear"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
         assert grid.contains_collapsed_cells
         assert grid.contains_smashed_cells is False
         assert grid.contains_duplicated_cells
@@ -164,6 +169,7 @@ def test_grid_init_da_tas_regular(mini_esgf_data):
         assert grid.lon == da.lon.name
         assert grid.type == "regular_lat_lon"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
         assert grid.contains_collapsed_cells is None
         assert grid.contains_duplicated_cells is False
         assert grid.lat_bnds is None
@@ -186,6 +192,7 @@ def test_grid_init_ds_tos_curvilinear(mini_esgf_data):
         assert grid.lon == ds.longitude.name
         assert grid.type == "curvilinear"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
         assert grid.lat_bnds == "vertices_latitude"
         assert grid.lon_bnds == "vertices_longitude"
         assert grid.contains_collapsed_cells
@@ -211,6 +218,7 @@ def test_grid_init_ds_tas_cordex(mini_esgf_data):
         assert grid.lon == "lon"
         assert grid.type == "curvilinear"
         assert grid.extent == "regional"
+        assert grid.extent_lat == "regional"
         assert grid.lat_bnds == "lat_vertices"
         assert grid.lon_bnds == "lon_vertices"
         assert not grid.contains_collapsed_cells
@@ -247,7 +255,8 @@ def test_grid_init_ds_cordex_erroneous_bounds(mini_esgf_data):
         assert grid.lat == "lat"
         assert grid.lon == "lon"
         assert grid.type == "curvilinear"
-        assert grid.extent == "global"  # extent in lon only!
+        assert grid.extent == "global"
+        assert grid.extent_lat == "regional"
         assert grid.lat_bnds is None
         assert grid.lon_bnds is None
         assert not grid.contains_collapsed_cells
@@ -277,7 +286,8 @@ def test_grid_init_ds_tas_cordex_ant(mini_esgf_data):
         assert grid.lat == "lat"
         assert grid.lon == "lon"
         assert grid.type == "curvilinear"
-        assert grid.extent == "global"  # only extent in longitude is checked
+        assert grid.extent == "global"
+        assert grid.extent_lat == "regional"
         assert grid.lat_bnds is None
         assert grid.lon_bnds is None
         assert not grid.contains_collapsed_cells
@@ -308,6 +318,7 @@ def test_grid_init_shifted_lon_frame_GFDL(mini_esgf_data):
 
         assert grid.type == "curvilinear"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
 
 
 def test_grid_init_shifted_lon_frame_IITM(mini_esgf_data):
@@ -328,6 +339,7 @@ def test_grid_init_shifted_lon_frame_IITM(mini_esgf_data):
 
         assert grid.type == "curvilinear"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
 
 
 @pytest.mark.slow
@@ -361,6 +373,7 @@ def test_grid_init_ds_tas_unstructured(mini_esgf_data):
         assert grid.lon == ds.longitude.name
         assert grid.type == "unstructured"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
         assert not grid.contains_collapsed_cells
         assert not grid.contains_duplicated_cells
         assert grid.lat_bnds == "latitude_bnds"
@@ -427,6 +440,7 @@ def test_grid_init_ds_erroneous_cf_units_cmip5(mini_esgf_data):
         assert grid.lon == "lon"
         assert grid.type == "curvilinear"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
         assert not grid.contains_collapsed_cells
         assert not grid.contains_duplicated_cells
         # Only the bounds for grid_latitude/longitude are specified
@@ -460,6 +474,7 @@ def test_grid_init_ds_erroneous_cf_units_cmip6(mini_esgf_data):
         assert grid.lon == "longitude"
         assert grid.type == "curvilinear"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
         assert not grid.contains_collapsed_cells
         assert not grid.contains_duplicated_cells
         # Only the bounds for grid_latitude/longitude are specified
@@ -499,6 +514,7 @@ def test_grid_init_ds_erroneous_cf_attrs_cmip6(mini_esgf_data):
         assert grid.lon == "longitude"
         assert grid.type == "curvilinear"
         assert grid.extent == "global"
+        assert grid.extent_lat == "global"
         assert not grid.contains_collapsed_cells
         assert not grid.contains_duplicated_cells
         # Only the bounds for grid_latitude/longitude are specified
@@ -519,6 +535,7 @@ def test_grid_instructor_global():
     assert grid.lon == "lon"
     assert grid.type == "regular_lat_lon"
     assert grid.extent == "global"
+    assert grid.extent_lat == "global"
     assert not grid.contains_collapsed_cells
     assert not grid.contains_duplicated_cells
 
@@ -545,6 +562,7 @@ def test_grid_instructor_2d_regional_change_lon():
     assert grid.lon == "lon"
     assert grid.type == "regular_lat_lon"
     assert grid.extent == "regional"
+    assert grid.extent_lat == "global"
     assert not grid.contains_collapsed_cells
     assert not grid.contains_duplicated_cells
 
@@ -570,11 +588,8 @@ def test_grid_instructor_2d_regional_change_lat():
     assert grid.lat == "lat"
     assert grid.lon == "lon"
     assert grid.type == "regular_lat_lon"
-
-    # Extent in y-direction ignored, as not of importance
-    #  for xesmf.Regridder. Extent in x-direction should be
-    #  detected as "global"
     assert grid.extent == "global"
+    assert grid.extent_lat == "regional"
 
     assert not grid.contains_collapsed_cells
     assert not grid.contains_duplicated_cells
@@ -598,6 +613,7 @@ def test_grid_instructor_2d_regional_change_lon_and_lat():
     assert grid.lon == "lon"
     assert grid.type == "regular_lat_lon"
     assert grid.extent == "regional"
+    assert grid.extent_lat == "regional"
     assert not grid.contains_collapsed_cells
     assert not grid.contains_duplicated_cells
 
@@ -624,6 +640,7 @@ def test_grid_instructor_2d_global():
     assert grid.lon == "lon"
     assert grid.type == "regular_lat_lon"
     assert grid.extent == "global"
+    assert grid.extent_lat == "global"
     assert not grid.contains_collapsed_cells
     assert not grid.contains_duplicated_cells
 
@@ -649,6 +666,7 @@ def test_from_grid_id():
     assert grid.lon == "lon"
     assert grid.type == "regular_lat_lon"
     assert grid.extent == "global"
+    assert grid.extent_lat == "global"
     assert not grid.contains_collapsed_cells
     assert not grid.contains_duplicated_cells
     assert grid.lat_bnds == "lat_bnds"
@@ -729,6 +747,12 @@ class TestGridFromDS:
             assert gAa.extent == "global"
             assert gBa.extent == "global"
             assert gCa.extent == "global"
+            assert gA.extent_lat == "global"
+            assert gB.extent_lat == "global"
+            assert gC.extent_lat == "global"
+            assert gAa.extent_lat == "global"
+            assert gBa.extent_lat == "global"
+            assert gCa.extent_lat == "global"
 
     def test_grid_from_ds_adaptive_reproducibility(self):
         """Test that the extent is evaluated as global for original and derived adaptive grid."""
@@ -743,8 +767,10 @@ class TestGridFromDS:
         gB = Grid(grid_id="1deg")
 
         assert gA.extent == "global"
+        assert gA.extent_lat == "global"
         assert gA.compare_grid(gAa)
         assert gB.extent == "global"
+        assert gB.extent_lat == "global"
         assert gB.compare_grid(gBa)
 
 
@@ -794,8 +820,6 @@ def test_compare_grid_hash_dict_and_verbose(capfd):
 
 def test_to_netcdf(tmp_path, mini_esgf_data):
     """Test if grid file is properly written to disk using to_netcdf method."""
-    pytest.importorskip("netCDF4", minversion="1.5.7", reason="Malformed test data only works with netCDF4 engine.")
-
     # Create Grid object
     dsA = xr.open_dataset(mini_esgf_data["CMIP6_TAS_PRECISION_A"])
     gA = Grid(ds=dsA)
@@ -803,7 +827,7 @@ def test_to_netcdf(tmp_path, mini_esgf_data):
     # Save to disk
     outdir = Path(tmp_path, "grids")
     outfile = "grid_test.nc"
-    gA.to_netcdf(folder=outdir, filename=outfile, engine="netcdf4")
+    gA.to_netcdf(folder=outdir, filename=outfile, engine="h5netcdf")
 
     # Read from disk - ensure outfile has been created and lockfile deleted
     assert os.path.isfile(Path(outdir, outfile))
@@ -816,6 +840,7 @@ def test_to_netcdf(tmp_path, mini_esgf_data):
     assert gA.format == gB.format
     assert gA.type == gB.type
     assert gA.extent == gB.extent
+    assert gA.extent_lat == gB.extent_lat
     assert gA.source == gB.source
     assert gA.contains_collapsed_cells == gB.contains_collapsed_cells
     assert sorted(list(gA.ds.attrs.keys()) + ["clisops"]) == sorted(list(gB.ds.attrs.keys()))
@@ -917,6 +942,7 @@ def test_subsetted_grid(mini_esgf_data):
     assert grid.lon == ds.lon.name
     assert grid.type == "regular_lat_lon"
     assert grid.extent == "regional"
+    assert grid.extent_lat == "regional"
     assert not grid.contains_collapsed_cells
     assert not grid.contains_duplicated_cells
 
@@ -1067,11 +1093,13 @@ class TestWeights:
         grid_in = Grid(ds=ds)
 
         assert grid_in.extent == "global"
+        assert grid_in.extent_lat == "global"
 
         grid_instructor_out = (0, 360, 1.5, -90, 90, 1.5)
         grid_out = Grid(grid_instructor=grid_instructor_out)
 
         assert grid_out.extent == "global"
+        assert grid_out.extent_lat == "global"
 
         weights_cache_init(Path(tmp_path, "weights"))
         w = Weights(grid_in=grid_in, grid_out=grid_out, method="bilinear")
@@ -1094,11 +1122,13 @@ class TestWeights:
         grid_in = Grid(ds=ds)
 
         assert grid_in.extent == "global"
+        assert grid_in.extent_lat == "global"
 
         grid_instructor_out = (0, 360, 1.5, -90, 90, 1.5)
         grid_out = Grid(grid_instructor=grid_instructor_out)
 
         assert grid_out.extent == "global"
+        assert grid_out.extent_lat == "global"
 
         weights_cache_init(Path(tmp_path, "weights"))
         w = Weights(grid_in=grid_in, grid_out=grid_out, method="conservative")
@@ -1191,8 +1221,6 @@ def test_Weights_compute(tmp_path):
 @pytest.mark.skipif(xesmf is None, reason=XESMF_IMPORT_MSG)
 def test_Weights_compute_unstructured(tmp_path, mini_esgf_data):
     """Test the generation of Weights for unstructured grids with the _compute method."""
-    pytest.importorskip("netCDF4", minversion="1.5.7", reason="Malformed test data only works with netCDF4 engine.")
-
     ds = xr.open_dataset(
         mini_esgf_data["CMIP6_UNSTR_ICON_A"],
         decode_times=xr.coders.CFDatetimeCoder(use_cftime=True),
@@ -1432,7 +1460,9 @@ class TestRegrid:
                 regrid(self.grid_in, self.grid_out, w, adaptive_masking_threshold=0.0)
                 if not issuedWarnings:
                     raise RuntimeError("No warning issued regarding the duplicated cells in the grid.")
-                elif Version(xr.__version__) >= Version("2023.3.0"):
+                elif Version(xr.__version__) >= Version(XARRAY_INCOMPATIBLE_VERSION) and Version(
+                    xr.__version__
+                ) < Version(XARRAY_COMPATIBLE_VERSION):
                     # Warning will also be issued for xarray being too new
                     assert len(issuedWarnings) == 2
                 else:
@@ -1479,7 +1509,6 @@ class TestRegrid:
 @pytest.mark.skipif(xesmf is None, reason=XESMF_IMPORT_MSG)
 def test_duplicated_cells_renormalization(tmp_path, mini_esgf_data):
     # TODO: Should probably be an xesmf test as well, will do PR there in the future
-    pytest.importorskip("netCDF4", minversion="1.5.7", reason="Malformed test data only works with netCDF4 engine.")
 
     with xr.open_dataset(
         mini_esgf_data["CMIP6_STAGGERED_UCOMP"],
@@ -1527,3 +1556,31 @@ def test_duplicated_cells_renormalization(tmp_path, mini_esgf_data):
         r5 = w.regridder(ds["tauuo"], skipna=True, na_thres=0.0)
         assert r4.where(r4 > 1.0, 0.0).sum() > 0.0
         assert r5.where(r5 > 1.0, 0.0).sum() == 0.0
+
+
+@pytest.mark.skipif(xesmf is None, reason=XESMF_IMPORT_MSG)
+def test_regrid_post_mask_source_option(tmpdir):
+    # Define source and target grids
+    grid_in = Grid(grid_instructor=(0.5, 10.5, 1, 0.5, 10.5, 1))
+    da_in = xr.DataArray(np.ones((10, 10)), dims=["lat", "lon"])
+    da_in[0, :] = 10  # top edge
+    da_in[-1, :] = 10  # bottom edge
+    grid_in.ds["var"] = da_in
+    grid_out = Grid(grid_instructor=(-0.5, 15.5, 1, -0.5, 15.5, 1))
+
+    # Calculate weights
+    weights_cache_init(Path(tmpdir, "weights"))
+    w = Weights(grid_in=grid_in, grid_out=grid_out, method="nearest_s2d")
+
+    # Regridding
+    ds_tgt = regrid(grid_in, grid_out, w)
+
+    # Check that edge values (10) did not make it into the result
+    assert not np.any(ds_tgt["var"].values > 1), "Edge contributions were not removed"
+
+    # Check that cells outside the original domain are 0
+    xlat, xlon = np.meshgrid(ds_tgt.lat.values, ds_tgt.lon.values)
+    assert np.all(np.isnan(ds_tgt["var"][:, 0].values))
+    assert np.all(np.isnan(ds_tgt["var"][0, :].values))
+    assert np.all(np.isnan(ds_tgt["var"][-1, :].values))
+    assert np.all(np.isnan(ds_tgt["var"][:, -1].values))

--- a/tests/test_ops_regrid.py
+++ b/tests/test_ops_regrid.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from pathlib import Path
 
 import cf_xarray  # noqa: F401
@@ -10,7 +9,6 @@ from roocs_grids import get_grid_file, grid_dict
 from clisops.core.regrid import XESMF_MINIMUM_VERSION, weights_cache_init, xe
 from clisops.ops.regrid import regrid
 from clisops.ops.subset import subset
-from clisops.utils.testing import ContextLogger
 
 XESMF_IMPORT_MSG = f"xESMF >= {XESMF_MINIMUM_VERSION} is needed for regridding functionalities."
 
@@ -158,18 +156,6 @@ def test_regrid_ATLAS_datasets(tmpdir, dset, mini_esgf_data):
 @pytest.mark.skipif(xe is None, reason=XESMF_IMPORT_MSG)
 def test_regrid_ATLAS_CORDEX(tmpdir, caplog, mini_esgf_data):
     """Test regridding for ATLAS CORDEX dataset."""
-    netcdf4 = pytest.importorskip(
-        "netCDF4", minversion="1.5.7", reason="Malformed test data only works with netCDF4 engine."
-    )
-
-    with ContextLogger(caplog) as _logger:
-        _logger.add(sys.stdout, level="INFO")
-        caplog.set_level("INFO", logger="clisops")
-
-        _logger.info("netcdf4-python version: %s" % netcdf4.__version__)
-        _logger.info("HDF5 lib version:       %s" % netcdf4.__hdf5libversion__)
-        _logger.info("netcdf lib version:     %s" % netcdf4.__netcdf4libversion__)
-
     ds = xr.open_dataset(
         mini_esgf_data["ATLAS_v0_CORDEX_ANT"],
         decode_times=xr.coders.CFDatetimeCoder(use_cftime=True),
@@ -206,8 +192,6 @@ def test_regrid_ATLAS_CORDEX(tmpdir, caplog, mini_esgf_data):
 @pytest.mark.skipif(xe is None, reason=XESMF_IMPORT_MSG)
 def test_regrid_keep_attrs(tmp_path, mini_esgf_data):
     """Test if dataset and variable attributes are kept / removed as specified."""
-    pytest.importorskip("netCDF4", minversion="1.5.7", reason="Malformed test data only works with netCDF4 engine.")
-
     fpath = mini_esgf_data["CMIP6_TOS_ONE_TIME_STEP"]
     method = "nearest_s2d"
 
@@ -306,8 +290,6 @@ class TestRegridHalo:
 @pytest.mark.skipif(xe is None, reason=XESMF_IMPORT_MSG)
 def test_regrid_shifted_lon_frame(tmp_path, mini_esgf_data):
     """Test regridding of dataset with shifted longitude frame."""
-    pytest.importorskip("netCDF4", minversion="1.5.7", reason="Malformed test data only works with netCDF4 engine.")
-
     fpath = mini_esgf_data["CMIP6_IITM_EXTENT"]
     ds = xr.open_dataset(fpath).isel(time=0)
 
@@ -353,8 +335,6 @@ def test_regrid_same_grid_exception(tmpdir, tmp_path):
 @pytest.mark.skipif(xe is None, reason=XESMF_IMPORT_MSG)
 def test_regrid_cmip6_nc_consistent_bounds_and_coords(tmpdir, mini_esgf_data):
     """Tests clisops regrid function and check metadata added by xarray"""
-    pytest.importorskip("netCDF4", minversion="1.5.7", reason="Malformed test data only works with netCDF4 engine.")
-
     result = regrid(
         ds=mini_esgf_data["CMIP6_ATM_VERT_ONE_TIMESTEP"],
         method="nearest_s2d",

--- a/tests/test_ops_subset.py
+++ b/tests/test_ops_subset.py
@@ -623,10 +623,6 @@ def test_time_invariant_subset_standard_name(tmpdir, check_output_nc, mini_esgf_
     check_output_nc(result, fname="mrsofc_fx_IPSL-CM6A-LR_ssp119_r1i1p1f1_gr.nc")
 
 
-@pytest.mark.xfail(
-    reason="Dataset metadata are badly encoded and not easily handled by h5netcdf",
-    strict=False,
-)
 def test_longitude_and_latitude_coords_only(tmpdir, check_output_nc, mini_esgf_data):
     """Test subset succeeds when latitude and longitude are coordinates not dims and are not called lat/lon"""
     result = subset(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->

- Fixed `regrid.ipynb` 
- Removed need for `psymaps` / `psyplot` dependency
- `utils/common.py`:
  - Updated `require_module` to accept an interval of unsupported versions
- `utils/dataset_utils.py`:
  - Added option to `get_coord_by_type` to suppress warning about a main variable not being identifiable
- `utils/output_utils.py`:
  - Added functions `fix_netcdf_attrs_encoding` and '`_fix_str_encoding` to fix utf-8 encoding issues for global and variable attributes
- `ops/base_operation.py`:
  - Applying above fix to correct utf-8 encoding issues
- `core/regrid.py`:
  - `xarray` version warning correctly triggered for versions outside of compatible version interval
  - `Grid.detect_extent`:
    + determins now also extent in latitude
    + using now average resolution in x and y direction, respectively, rather than the average resolution, to determine the extent in lon/lat  direction
    + now returning `(lon_extent, lat_extent)` instead of just `lon_extent`
  - `Grid._grid_from_ds_adaptive`:
    + Added fix for regional grids that include either meridian or antimeridian
  - `Grid.to_netcdf`:
    + Added fix for `ds.encoding['unlimited_dims']` not being updated by `xarray`  when dropping all time-dependent variables to write out solely the horizontal grid
    + Applying above fix for utf-8 encoding issues
  - `Grid.extent_lat`: added new attribute
  - `Weights`:
    + Will now use `post_mask_source='domain_edge'` setting when remapping a regional grid via nearest neighbour method, to avoid extrapolation beyond the original source domain (xESMF PR yet to be approved and merged)
- Tests:
  - Added / modified tests for code changes
  - Reverted skipping or xfailing tests that used to fail with `engine="h5netcdf"`

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->

`clisops.core.regrid.Grid.detect_extent` now returns the tuple `(lon_extent, lat_extent)` rather than just `lon_extent`

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->

I can update `HISTORY.rst` once all changes made by the PR are approved and potential feedback worked in.