### PR TITLE
Faster subset gridpoint

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ New Features
 ^^^^^^^^^^^^
 * Added an `engine` argument to `Grid.ds.to_netcdf()` to allow users to specify the engine used for writing NetCDF files (#439).
 * Coding conventions have been updated to use Python 3.10+ features (#439).
+* `core.subset.subset_gridpoint` will find nearest neighbours using a KDTree based on euclidean distance in lat/lon space instead of using great circle distances. The small loss in precision is compensated by a significant performance boost, especially for large grids and long point lists (#452).
 
 Bug Fixes
 ^^^^^^^^^

--- a/clisops/utils/dataset_utils.py
+++ b/clisops/utils/dataset_utils.py
@@ -174,6 +174,9 @@ def is_latitude(coord: xr.DataArray | xr.Dataset) -> bool:
     if hasattr(coord, "long_name") and coord.long_name == "latitude":
         return True
 
+    if coord.name == "lat":
+        return True
+
     return False
 
 
@@ -201,6 +204,9 @@ def is_longitude(coord: xr.DataArray | xr.Dataset) -> bool:
         return True
 
     if hasattr(coord, "long_name") and coord.long_name == "longitude":
+        return True
+
+    if coord.name == "lon":
         return True
 
     return False

--- a/tests/test_core_subset.py
+++ b/tests/test_core_subset.py
@@ -177,6 +177,7 @@ class TestSubsetGridPoint:
         da = xr.open_mfdataset(
             [nimbus.fetch(self.nc_tasmax_file), nimbus.fetch(self.nc_tasmin_file)],
             combine="by_coords",
+            compat="override",
         )
         lon = -72.4
         lat = 46.1
@@ -222,15 +223,7 @@ class TestSubsetGridPoint:
 
         # test_irregular transposed:
         da1 = xr.open_dataset(nimbus.fetch(self.nc_2dlonlat)).tasmax
-        dims = list(da1.dims)
-        dims.reverse()
-        daT = xr.DataArray(np.transpose(da1.values), dims=dims)
-        for d in daT.dims:
-            args = dict()
-            args[d] = da1[d]
-            daT = daT.assign_coords(**args)
-        daT = daT.assign_coords(lon=(["rlon", "rlat"], np.transpose(da1.lon.values)))
-        daT = daT.assign_coords(lat=(["rlon", "rlat"], np.transpose(da1.lat.values)))
+        daT = da1.transpose(*list(reversed(da1.dims)))
 
         out1 = subset.subset_gridpoint(daT, lon=lon, lat=lat)
         np.testing.assert_almost_equal(out1.lon, lon, 1)
@@ -238,15 +231,7 @@ class TestSubsetGridPoint:
         np.testing.assert_array_equal(out, out1)
 
         # Dataset with tasmax, lon and lat as data variables (i.e. lon, lat not coords of tasmax)
-        daT1 = xr.DataArray(np.transpose(da1.values), dims=dims)
-        for d in daT1.dims:
-            args = dict()
-            args[d] = da1[d]
-            daT1 = daT1.assign_coords(**args)
-        dsT = xr.Dataset(data_vars=None, coords=daT1.coords)
-        dsT["tasmax"] = daT1
-        dsT["lon"] = xr.DataArray(np.transpose(da1.lon.values), dims=["rlon", "rlat"])
-        dsT["lat"] = xr.DataArray(np.transpose(da1.lat.values), dims=["rlon", "rlat"])
+        dsT = daT.to_dataset().reset_coords(["lon", "lat"])
         out2 = subset.subset_gridpoint(dsT, lon=lon, lat=lat)
         np.testing.assert_almost_equal(out2.lon, lon, 1)
         np.testing.assert_almost_equal(out2.lat, lat, 1)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->
When subsetting a curvilinear dataset (2D lat lon) to gridpoints, use a `scipy.spatial.KDTree` to find nearest neighbours with euclidean distance in lat/lon space, instead of computing the great circle distance (in meters) for all points.

We are already using a lat/lon euclidean distance for the rectilinear case (1D lat / lon). The loss in precision is compensated by a significant performance boost. For example, my use case needed to extract 94 points from a 800x1000 grid. Instead of computing 94x1000x800 great circle distances, we now only need to compute 94 when tolerance is passed. None otherwise.

Before this change, my use case took ~120 s and now it takes 350 ms.

I also modified how we get the lat and lon coordinate to use the utils instead of relying on `lat` and `lon` names. And I modified these utils so a variable named "lon" is detected as a longitude (and similarly for "lat").

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->
Kinda as the distance metric has changed. In most cases, I don't expect different result, but there could be some extreme cases with points near the poles where a different neighbour is now choosed.

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->
