### PR TITLE
Subset gridpoint masking and distance and geographic methods for all grid types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ v0.17.0 (2025-12-16)
 
 New Features
 ^^^^^^^^^^^^
+* Added support for a data mask in `subset_gridpoint` where the subsetted grid points but be within the mask (True) (#493).
+* Allows choice between using true world distance (`distance`) or nearest neighbour based on lat, lon (`geographic`) methods for subsetting both regular and irregular grids (#493). 
 * Added an `engine` argument to `Grid.ds.to_netcdf()` to allow users to specify the engine used for writing NetCDF files (#439).
 * Coding conventions have been updated to use Python 3.10+ features (#439).
 * `Weights` will now use `post_mask_source='domain_edge'` introduced in `xesmf` version 0.9 when remapping a regional grid via nearest-neighbour to avoid extrapolation beyond the source domain (#447).
@@ -25,6 +27,7 @@ Bug Fixes
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+* Default method for `subset_gridpoint` using regular lat,lon grids is now `distance` instead of previously employing the equivalent of the new `geographic` method (#493).
 * Support for Python 3.10 has been dropped. `numpy >=1.26` is the new minimum supported version (#469).
 * `Grid.detect_extent()` now returns a tuple `(lon_extent, lat_extent)` instead of only `lon_extent` (#447).
 * `Grid.extent` now represents the combined lon/lat extent: `"global"` if both are global; otherwise `"regional"`. The new `Grid.extent_lon` and `Grid.extent_lat` attributes provide axis-specific extent information (#447).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ v0.17.0 (2025-12-16)
 New Features
 ^^^^^^^^^^^^
 * Added support for a data mask in `subset_gridpoint` where the subsetted grid points but be within the mask (True) (#493).
-* Allows choice between using true world distance (`distance`) or nearest neighbour based on lat, lon (`geographic`) methods for subsetting both regular and irregular grids (#493). 
+* Allows choice between using true world distance (`distance`) or nearest neighbour based on lat, lon (`geographic`) methods for subsetting both regular and irregular grids (#493).
 * Added an `engine` argument to `Grid.ds.to_netcdf()` to allow users to specify the engine used for writing NetCDF files (#439).
 * Coding conventions have been updated to use Python 3.10+ features (#439).
 * `Weights` will now use `post_mask_source='domain_edge'` introduced in `xesmf` version 0.9 when remapping a regional grid via nearest-neighbour to avoid extrapolation beyond the source domain (#447).

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1516,6 +1516,7 @@ def subset_gridpoint(
     da: xarray.DataArray | xarray.Dataset,
     lon: float | Sequence[float] | xarray.DataArray | None = None,
     lat: float | Sequence[float] | xarray.DataArray | None = None,
+    method: str | None = "distance",
     start_date: str | None = None,
     end_date: str | None = None,
     first_level: float | int | None = None,
@@ -1540,6 +1541,9 @@ def subset_gridpoint(
         Longitude coordinate(s). Must be of the same length as lat.
     lat : float, Sequence[float], xarray.DataArray, optional
         Latitude coordinate(s). Must be of the same length as lon.
+    method : str, optional
+        Method to use for finding the nearest grid point. Options are "geographic" (default) and "distance"; 
+        "geographic" uses longitude and latitude coordinates directly while "distance" calculates distances on the Earth's surface.
     start_date : str, optional
         Start date of the subset.
         Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
@@ -1584,38 +1588,101 @@ def subset_gridpoint(
         ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])
         dsSub = subset_gridpoint(ds, lon=-75, lat=45)
     """
-    def _subset_gridpoint_mask(da, lat, lon, mask):
+    def _subset_gridpoint_mask(
+            da: xarray.DataArray | xarray.Dataset,
+            lon: float | Sequence[float] | xarray.DataArray | None = None,
+            lat: float | Sequence[float] | xarray.DataArray | None = None,
+            mask: np.ndarray | xarray.DataArray | None = None,
+            ptdim: str | None = None,
+        ) -> xarray.DataArray | xarray.Dataset: 
         
-        # 1. Apply mask and extract coordinates of valid points
-        # Create a 2D array of (lon, lat) pairs from the valid data
-        lon_grid, lat_grid = xarray.broadcast(da.lon, da.lat)
-        lon_grid = lon_grid.where(mask)
-        lat_grid = lat_grid.where(mask)
-        
-        # Flatten and remove NaNs (points that didn't pass the mask)
-        v_lons = lon_grid.values.ravel()
-        v_lats = lat_grid.values.ravel()
-        valid_idx = ~np.isnan(v_lons)
-        
-        coords_pool = np.column_stack((v_lons[valid_idx], v_lats[valid_idx]))
+        dims = list(da.dims)
+        dists = None
+        lon_name = lon.name or "lon"
+        lat_name = lat.name or "lat"
+        # if 'lon' and 'lat' are present as data dimensions use the .sel method.
+        dims_flag = lat_name in dims and lon_name in dims
+        if mask is None and method == "geographic" and dims_flag:
+            da = da.sel(lat=lat, lon=lon, method="nearest")
+            if add_distance or tolerance is not None:
+                dists = distance(da, lon=lon, lat=lat)
+        elif (mask is not None and method == "geographic") or (method == "geographic" and not dims_flag):
+            # 1. Apply mask and extract coordinates of valid points
+            # Create a 2D array of (lon, lat) pairs from the valid data
+            if len(da[lat_name].dims) == 1 and len(da[lon_name].dims) == 1:
+                lon_grid, lat_grid = xarray.broadcast(da[lon_name], da[lat_name])
+            elif len(da[lat_name].dims) == 2 and len(da[lon_name].dims) == 2:
+                lon_grid = da[lon_name]
+                lat_grid = da[lat_name]
+            else:
+                raise ValueError("Latitude and longitude coordinates must be either 1D or 2D arrays.")
+            
+            dim0, dim1 = lat_grid.dims
+            if mask is not None:
+                lon_grid = lon_grid.where(mask)
+                lat_grid = lat_grid.where(mask)
+            
+            # Flatten and remove NaNs (points that didn't pass the mask)
+            v_lons = lon_grid.values.ravel()
+            v_lats = lat_grid.values.ravel()
+            valid_idx = ~np.isnan(v_lons)
+            
+            coords_pool = np.column_stack((v_lons[valid_idx], v_lats[valid_idx]))
 
-        # 2. Build the KD Tree
-        tree = KDTree(coords_pool)
+            # 2. Build the KD Tree
+            tree = KDTree(coords_pool)
 
-        # 3. Batch Query for all sites
-        # target_lons/lats should be lists or 1D arrays of equal length
-        targets = np.column_stack((lon, lat))
-        distances, indices = tree.query(targets)
+            # 3. Batch Query for all sites
+            # target_lons/lats should be lists or 1D arrays of equal length
+            targets = np.column_stack((lon, lat))
+            distances, indices = tree.query(targets)
 
-        # 4. Extract the closest valid coordinates
-        nearest_coords = coords_pool[indices]
+            # 4. Extract the closest valid coordinates
+            nearest_coords = coords_pool[indices]
 
-        # 5. Convert result to DataArrays for xarray indexing
-        nearest_lons = nearest_coords[:, 0]
-        nearest_lats = nearest_coords[:, 1]
+            # 5. Convert result to DataArrays for xarray indexing
+            nearest_lons = nearest_coords[:, 0]
+            nearest_lats = nearest_coords[:, 1]
 
-        #6. subset ds
-        return da.sel(lon=nearest_lons, lat=nearest_lats)    
+            #6. subset ds
+            idx = []
+            for i in range(len(nearest_lons)):
+                idx1 = np.where((lon_grid == nearest_lons[i]) & (lat_grid == nearest_lats[i]))
+                idx.append(idx1)
+            idx =  np.where((np.isin(lon_grid, nearest_lons)) & (np.isin(lat_grid, nearest_lats)))
+
+            da = da.isel({dim0: xarray.DataArray(idx[0], dims=ptdim), dim1: xarray.DataArray(idx[1], dims=ptdim)})
+            
+            if add_distance is not None or tolerance is not None:
+                # Calculate the geodesic distance between grid points and the point of interest.
+                dists = distance(da, lon=lon, lat=lat, mask=mask)
+        elif method == "distance":
+            dist = distance(da, lon=lon, lat=lat, mask=mask)               
+            args = None
+            for site in dist[ptdim]:
+                # Find the indices for the closest point
+                distances = dist.sel({ptdim: site})
+                inds = np.unravel_index(np.nanargmin(distances), distances.shape)
+                args1 = {xydim: ind for xydim, ind in zip(dist.dims, inds, strict=False)}
+                # Select data from closest point
+                if args is None:
+                    args = args1
+                else:
+                    # add to existing args
+                    args = {k: [args.get(k), args1.get(k)] for k in args.keys() | args1.keys()}
+                #pts.append(da.isel(**args))
+                #dists.append(dist.isel(**args))
+            for k, v in args.items():
+                args[k] = xarray.DataArray([v], dims=ptdim) if np.isscalar(v) else xarray.DataArray(v, dims=ptdim)
+
+            da = da.isel(**args)
+            if add_distance or tolerance is not None:
+                dists = dist.isel(**args)
+        else:
+            raise ValueError(f"Method {method} not recognized. Use 'geographic' or 'distance'.")
+            
+        return da, dists
+
     
     if lat is None or lon is None:
         raise ValueError("Insufficient coordinates provided to locate grid point(s).")
@@ -1627,35 +1694,9 @@ def subset_gridpoint(
 
     # make sure input data has 'lon' and 'lat'(dims, coordinates, or data_vars)
     if hasattr(da, lon_name) and hasattr(da, lat_name):
-        dims = list(da.dims)
+            
+        da, dist = _subset_gridpoint_mask(da=da, lat=lat, lon=lon, mask=mask, ptdim=ptdim)
 
-        # if 'lon' and 'lat' are present as data dimensions use the .sel method.
-        if lat_name in dims and lon_name in dims:
-            if mask is None:
-                da = da.sel(lat=lat, lon=lon, method="nearest")
-
-            if tolerance is not None or add_distance:
-                # Calculate the geodesic distance between grid points and the point of interest.
-                dist = distance(da, lon=lon, lat=lat)
-            else:
-                dist = None
-
-        else:
-            # Calculate the geodesic distance between grid points and the point of interest.
-            dist = distance(da, lon=lon, lat=lat)
-            pts = []
-            dists = []
-            for site in dist[ptdim]:
-                # Find the indices for the closest point
-                distances = dist.sel({ptdim: site})
-                inds = np.unravel_index(np.nanargmin(distances), distances.shape)
-
-                # Select data from closest point
-                args = {xydim: ind for xydim, ind in zip(dist.dims, inds, strict=False)}
-                pts.append(da.isel(**args))
-                dists.append(dist.isel(**args))
-            da = xarray.concat(pts, dim=ptdim)
-            dist = xarray.concat(dists, dim=ptdim)
     else:
         raise (
             Exception(
@@ -1943,6 +1984,7 @@ def distance(
     *,
     lon: float | Sequence[float] | xarray.DataArray,
     lat: float | Sequence[float] | xarray.DataArray,
+    mask: np.ndarray | xarray.DataArray | None = None,
 ) -> xarray.DataArray | xarray.Dataset:
     """
     Return distance to a point in meters.
@@ -1955,7 +1997,9 @@ def distance(
         Longitude coordinate.
     lat : float, sequence of floats, or xarray.DataArray
         Latitude coordinate.
-
+    mask : np.ndarray or xarray.DataArray, optional
+        2d boolean array with the same spatial dimensions as da, 
+        where True values indicate valid grid points to be considered for distance calculation. Optional.
     Returns
     -------
     xarray.DataArray
@@ -1981,9 +2025,18 @@ def distance(
     def _func(lons, lats, lon, lat):
         return g.inv(lons, lats, lon, lat)[2]
 
+    if len(da.lon.dims) == 1 and len(da.lat.dims) == 1:
+        lon_grid, lat_grid = xarray.broadcast(da.lon, da.lat)
+    else:
+        lon_grid = da.lon
+        lat_grid = da.lat
+    if mask is not None:
+        lon_grid = lon_grid.where(mask)
+        lat_grid = lat_grid.where(mask)
+
     out = xarray.apply_ufunc(
         _func,
-        *xarray.broadcast(da.lon.load(), da.lat.load(), lon, lat),
+        *xarray.broadcast(lon_grid.load(), lat_grid.load(), lon, lat),
         input_core_dims=[[ptdim]] * 4,
         output_core_dims=[[ptdim]],
     )

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -2023,7 +2023,16 @@ def distance(
     g = Geod(ellps="WGS84")  # WGS84 ellipsoid - decent globally
 
     def _func(lons, lats, lon, lat):
-        return g.inv(lons, lats, lon, lat)[2]
+        if hasattr(lons, "item"):
+            lons = lons.item()
+        if hasattr(lats, "item"):
+            lats = lats.item()
+        if hasattr(lon, "item"):
+            lon = lon.item()
+        if hasattr(lat, "item"):
+            lat = lat.item()
+        out = g.inv(lons, lats, lon, lat)[2]
+        return np.atleast_3d(out)
 
     if len(da.lon.dims) == 1 and len(da.lat.dims) == 1:
         lon_grid, lat_grid = xarray.broadcast(da.lon, da.lat)

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1542,7 +1542,7 @@ def subset_gridpoint(
     lat : float, Sequence[float], xarray.DataArray, optional
         Latitude coordinate(s). Must be of the same length as lon.
     method : str, optional
-        Method to use for finding the nearest grid point. Options are "geographic" (default) and "distance"; 
+        Method to use for finding the nearest grid point. Options are "geographic" (default) and "distance";
         "geographic" uses longitude and latitude coordinates directly while "distance" calculates distances on the Earth's surface.
     start_date : str, optional
         Start date of the subset.
@@ -1588,14 +1588,15 @@ def subset_gridpoint(
         ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])
         dsSub = subset_gridpoint(ds, lon=-75, lat=45)
     """
+
     def _subset_gridpoint_mask(
-            da: xarray.DataArray | xarray.Dataset,
-            lon: float | Sequence[float] | xarray.DataArray | None = None,
-            lat: float | Sequence[float] | xarray.DataArray | None = None,
-            mask: np.ndarray | xarray.DataArray | None = None,
-            ptdim: str | None = None,
-        ) -> xarray.DataArray | xarray.Dataset: 
-        
+        da: xarray.DataArray | xarray.Dataset,
+        lon: float | Sequence[float] | xarray.DataArray | None = None,
+        lat: float | Sequence[float] | xarray.DataArray | None = None,
+        mask: np.ndarray | xarray.DataArray | None = None,
+        ptdim: str | None = None,
+    ) -> xarray.DataArray | xarray.Dataset:
+
         dims = list(da.dims)
         dists = None
         lon_name = lon.name or "lon"
@@ -1616,17 +1617,17 @@ def subset_gridpoint(
                 lat_grid = da[lat_name]
             else:
                 raise ValueError("Latitude and longitude coordinates must be either 1D or 2D arrays.")
-            
+
             dim0, dim1 = lat_grid.dims
             if mask is not None:
                 lon_grid = lon_grid.where(mask)
                 lat_grid = lat_grid.where(mask)
-            
+
             # Flatten and remove NaNs (points that didn't pass the mask)
             v_lons = lon_grid.values.ravel()
             v_lats = lat_grid.values.ravel()
             valid_idx = ~np.isnan(v_lons)
-            
+
             coords_pool = np.column_stack((v_lons[valid_idx], v_lats[valid_idx]))
 
             # 2. Build the KD Tree
@@ -1644,20 +1645,20 @@ def subset_gridpoint(
             nearest_lons = nearest_coords[:, 0]
             nearest_lats = nearest_coords[:, 1]
 
-            #6. subset ds
+            # 6. subset ds
             idx = []
             for i in range(len(nearest_lons)):
                 idx1 = np.where((lon_grid == nearest_lons[i]) & (lat_grid == nearest_lats[i]))
                 idx.append(idx1)
-            idx =  np.where((np.isin(lon_grid, nearest_lons)) & (np.isin(lat_grid, nearest_lats)))
+            idx = np.where((np.isin(lon_grid, nearest_lons)) & (np.isin(lat_grid, nearest_lats)))
 
             da = da.isel({dim0: xarray.DataArray(idx[0], dims=ptdim), dim1: xarray.DataArray(idx[1], dims=ptdim)})
-            
+
             if add_distance is not None or tolerance is not None:
                 # Calculate the geodesic distance between grid points and the point of interest.
                 dists = distance(da, lon=lon, lat=lat, mask=mask)
         elif method == "distance":
-            dist = distance(da, lon=lon, lat=lat, mask=mask)               
+            dist = distance(da, lon=lon, lat=lat, mask=mask)
             args = None
             for site in dist[ptdim]:
                 # Find the indices for the closest point
@@ -1670,8 +1671,8 @@ def subset_gridpoint(
                 else:
                     # add to existing args
                     args = {k: [args.get(k), args1.get(k)] for k in args.keys() | args1.keys()}
-                #pts.append(da.isel(**args))
-                #dists.append(dist.isel(**args))
+                # pts.append(da.isel(**args))
+                # dists.append(dist.isel(**args))
             for k, v in args.items():
                 args[k] = xarray.DataArray([v], dims=ptdim) if np.isscalar(v) else xarray.DataArray(v, dims=ptdim)
 
@@ -1680,10 +1681,9 @@ def subset_gridpoint(
                 dists = dist.isel(**args)
         else:
             raise ValueError(f"Method {method} not recognized. Use 'geographic' or 'distance'.")
-            
+
         return da, dists
 
-    
     if lat is None or lon is None:
         raise ValueError("Insufficient coordinates provided to locate grid point(s).")
 
@@ -1694,7 +1694,6 @@ def subset_gridpoint(
 
     # make sure input data has 'lon' and 'lat'(dims, coordinates, or data_vars)
     if hasattr(da, lon_name) and hasattr(da, lat_name):
-            
         da, dist = _subset_gridpoint_mask(da=da, lat=lat, lon=lon, mask=mask, ptdim=ptdim)
 
     else:
@@ -1998,8 +1997,9 @@ def distance(
     lat : float, sequence of floats, or xarray.DataArray
         Latitude coordinate.
     mask : np.ndarray or xarray.DataArray, optional
-        2d boolean array with the same spatial dimensions as da, 
+        2d boolean array with the same spatial dimensions as da,
         where True values indicate valid grid points to be considered for distance calculation. Optional.
+
     Returns
     -------
     xarray.DataArray

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1543,7 +1543,7 @@ def subset_gridpoint(
         Latitude coordinate(s). Must be of the same length as lon.
     method : str, optional
         Method to use for finding the nearest grid point. Options are "geographic" (default) and "distance";
-        "geographic" uses longitude and latitude coordinates directly while "distance" calculates distance 
+        "geographic" uses longitude and latitude coordinates directly while "distance" calculates distance
         on the Earth's surface.
     start_date : str, optional
         Start date of the subset.
@@ -1566,7 +1566,7 @@ def subset_gridpoint(
     add_distance : bool
         Whether to add a new coordinate "distance" to the output DataArray or Dataset.
     mask : bool
-        2d boolean array with the same spatial dimensions as da, where True values indicate valid 
+        2d boolean array with the same spatial dimensions as da, where True values indicate valid
         grid points to be considered for subsetting.
 
     Returns

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1543,7 +1543,8 @@ def subset_gridpoint(
         Latitude coordinate(s). Must be of the same length as lon.
     method : str, optional
         Method to use for finding the nearest grid point. Options are "geographic" (default) and "distance";
-        "geographic" uses longitude and latitude coordinates directly while "distance" calculates distances on the Earth's surface.
+        "geographic" uses longitude and latitude coordinates directly while "distance" calculates distance 
+        on the Earth's surface.
     start_date : str, optional
         Start date of the subset.
         Date string format -- can be year ("%Y"), year-month ("%Y-%m") or year-month-day("%Y-%m-%d").
@@ -1565,7 +1566,8 @@ def subset_gridpoint(
     add_distance : bool
         Whether to add a new coordinate "distance" to the output DataArray or Dataset.
     mask : bool
-        2d boolean array with the same spatial dimensions as da, where True values indicate valid grid points to be considered for subsetting.
+        2d boolean array with the same spatial dimensions as da, where True values indicate valid 
+        grid points to be considered for subsetting.
 
     Returns
     -------

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -2024,6 +2024,7 @@ def distance(
 
     def _func(lons, lats, lon, lat):
         ndim = lons.ndim
+        outshape = lons.shape
         if hasattr(lons, "item") and lons.size == 1:
             lons = lons.item()
         if hasattr(lats, "item") and lats.size == 1:
@@ -2033,7 +2034,7 @@ def distance(
         if hasattr(lat, "item") and lat.size == 1:
             lat = lat.item()
         out = g.inv(lons, lats, lon, lat)[2]
-        return out if ndim == 0 else np.array(out).reshape(lons.shape)
+        return out if ndim == 0 else np.array(out).reshape(outshape)
 
     if len(da.lon.dims) == 1 and len(da.lat.dims) == 1:
         lon_grid, lat_grid = xarray.broadcast(da.lon, da.lat)

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -17,6 +17,7 @@ from pandas.api.types import is_integer_dtype
 from pyproj import Geod
 from pyproj.crs import CRS
 from pyproj.exceptions import CRSError
+from scipy.spatial import KDTree
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.ops import split, unary_union
 from xarray.core import indexing
@@ -1521,6 +1522,7 @@ def subset_gridpoint(
     last_level: float | int | None = None,
     tolerance: float | None = None,
     add_distance: bool = False,
+    mask: np.ndarray | xarray.DataArray | None = None,
 ) -> xarray.DataArray | xarray.Dataset:
     """
     Extract one or more of the nearest gridpoint(s) from datarray based on lat lon coordinate(s).
@@ -1558,6 +1560,8 @@ def subset_gridpoint(
         Masks values if the distance to the nearest gridpoint is larger than tolerance in meters.
     add_distance : bool
         Whether to add a new coordinate "distance" to the output DataArray or Dataset.
+    mask : bool
+        2d boolean array with the same spatial dimensions as da, where True values indicate valid grid points to be considered for subsetting.
 
     Returns
     -------
@@ -1580,6 +1584,39 @@ def subset_gridpoint(
         ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])
         dsSub = subset_gridpoint(ds, lon=-75, lat=45)
     """
+    def _subset_gridpoint_mask(da, lat, lon, mask):
+        
+        # 1. Apply mask and extract coordinates of valid points
+        # Create a 2D array of (lon, lat) pairs from the valid data
+        lon_grid, lat_grid = xarray.broadcast(da.lon, da.lat)
+        lon_grid = lon_grid.where(mask)
+        lat_grid = lat_grid.where(mask)
+        
+        # Flatten and remove NaNs (points that didn't pass the mask)
+        v_lons = lon_grid.values.ravel()
+        v_lats = lat_grid.values.ravel()
+        valid_idx = ~np.isnan(v_lons)
+        
+        coords_pool = np.column_stack((v_lons[valid_idx], v_lats[valid_idx]))
+
+        # 2. Build the KD Tree
+        tree = KDTree(coords_pool)
+
+        # 3. Batch Query for all sites
+        # target_lons/lats should be lists or 1D arrays of equal length
+        targets = np.column_stack((lon, lat))
+        distances, indices = tree.query(targets)
+
+        # 4. Extract the closest valid coordinates
+        nearest_coords = coords_pool[indices]
+
+        # 5. Convert result to DataArrays for xarray indexing
+        nearest_lons = nearest_coords[:, 0]
+        nearest_lats = nearest_coords[:, 1]
+
+        #6. subset ds
+        return da.sel(lon=nearest_lons, lat=nearest_lats)    
+    
     if lat is None or lon is None:
         raise ValueError("Insufficient coordinates provided to locate grid point(s).")
 
@@ -1594,7 +1631,8 @@ def subset_gridpoint(
 
         # if 'lon' and 'lat' are present as data dimensions use the .sel method.
         if lat_name in dims and lon_name in dims:
-            da = da.sel(lat=lat, lon=lon, method="nearest")
+            if mask is None:
+                da = da.sel(lat=lat, lon=lon, method="nearest")
 
             if tolerance is not None or add_distance:
                 # Calculate the geodesic distance between grid points and the point of interest.

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -2023,16 +2023,17 @@ def distance(
     g = Geod(ellps="WGS84")  # WGS84 ellipsoid - decent globally
 
     def _func(lons, lats, lon, lat):
-        if hasattr(lons, "item"):
+        ndim = lons.ndim
+        if hasattr(lons, "item") and lons.size == 1:
             lons = lons.item()
-        if hasattr(lats, "item"):
+        if hasattr(lats, "item") and lats.size == 1:
             lats = lats.item()
-        if hasattr(lon, "item"):
+        if hasattr(lon, "item") and lon.size == 1:
             lon = lon.item()
-        if hasattr(lat, "item"):
+        if hasattr(lat, "item") and lat.size == 1:
             lat = lat.item()
         out = g.inv(lons, lats, lon, lat)[2]
-        return np.atleast_3d(out)
+        return out if ndim == 0 else np.array(out).reshape(lons.shape)
 
     if len(da.lon.dims) == 1 and len(da.lat.dims) == 1:
         lon_grid, lat_grid = xarray.broadcast(da.lon, da.lat)

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1609,7 +1609,7 @@ def subset_gridpoint(
             da = da.sel(lat=lat, lon=lon, method="nearest")
             if add_distance or tolerance is not None:
                 dists = distance(da, lon=lon, lat=lat)
-        elif (mask is not None and method == "geographic") or (method == "geographic" and not dims_flag):
+        elif method == "geographic" and (mask is not None or not dims_flag):
             # 1. Apply mask and extract coordinates of valid points
             # Create a 2D array of (lon, lat) pairs from the valid data
             if len(da[lat_name].dims) == 1 and len(da[lon_name].dims) == 1:

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1657,23 +1657,15 @@ def subset_gridpoint(
                 dists = distance(da, lon=lon, lat=lat, mask=mask)
         elif method == "distance":
             dist = distance(da, lon=lon, lat=lat, mask=mask)
-            args = None
+            args = {xydim: [] for xydim in dist.dims}
             for site in dist[ptdim]:
                 # Find the indices for the closest point
                 distances = dist.sel({ptdim: site})
                 inds = np.unravel_index(np.nanargmin(distances), distances.shape)
-                args1 = {xydim: ind for xydim, ind in zip(dist.dims, inds, strict=False)}
-                # Select data from closest point
-                if args is None:
-                    args = args1
-                else:
-                    # add to existing args
-                    args = {k: [args.get(k), args1.get(k)] for k in args.keys() | args1.keys()}
-                # pts.append(da.isel(**args))
-                # dists.append(dist.isel(**args))
-            for k, v in args.items():
-                args[k] = xarray.DataArray([v], dims=ptdim) if np.isscalar(v) else xarray.DataArray(v, dims=ptdim)
-
+                for xydim, ind in zip(dist.dims, inds, strict=False):
+                    args[xydim].append(ind)
+            for xydim in dist.dims:
+                args[k] = xarray.DataArray(v, dims=ptdim)
             da = da.isel(**args)
             if add_distance or tolerance is not None:
                 dists = dist.isel(**args)
@@ -1696,7 +1688,7 @@ def subset_gridpoint(
 
     else:
         raise (
-            Exception(
+            ValueError(
                 f'{subset_gridpoint.__name__} requires input data with "lon" and "lat" coordinates or data variables.'
             )
         )

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1648,10 +1648,6 @@ def subset_gridpoint(
             nearest_lats = nearest_coords[:, 1]
 
             # 6. subset ds
-            idx = []
-            for i in range(len(nearest_lons)):
-                idx1 = np.where((lon_grid == nearest_lons[i]) & (lat_grid == nearest_lats[i]))
-                idx.append(idx1)
             idx = np.where((np.isin(lon_grid, nearest_lons)) & (np.isin(lat_grid, nearest_lats)))
 
             da = da.isel({dim0: xarray.DataArray(idx[0], dims=ptdim), dim1: xarray.DataArray(idx[1], dims=ptdim)})

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -2013,18 +2013,7 @@ def distance(
     g = Geod(ellps="WGS84")  # WGS84 ellipsoid - decent globally
 
     def _func(lons, lats, lon, lat):
-        ndim = lons.ndim
-        outshape = lons.shape
-        if hasattr(lons, "item") and lons.size == 1:
-            lons = lons.item()
-        if hasattr(lats, "item") and lats.size == 1:
-            lats = lats.item()
-        if hasattr(lon, "item") and lon.size == 1:
-            lon = lon.item()
-        if hasattr(lat, "item") and lat.size == 1:
-            lat = lat.item()
-        out = g.inv(lons, lats, lon, lat)[2]
-        return out if ndim == 0 else np.array(out).reshape(outshape)
+        return g.inv(lons, lats, lon, lat)[2]
 
     if len(da.lon.dims) == 1 and len(da.lat.dims) == 1:
         lon_grid, lat_grid = xarray.broadcast(da.lon, da.lat)

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1657,15 +1657,15 @@ def subset_gridpoint(
                 dists = distance(da, lon=lon, lat=lat, mask=mask)
         elif method == "distance":
             dist = distance(da, lon=lon, lat=lat, mask=mask)
-            args = {xydim: [] for xydim in dist.dims}
+            args = {xydim: [] for xydim in dist.dims if xydim != ptdim}
             for site in dist[ptdim]:
                 # Find the indices for the closest point
                 distances = dist.sel({ptdim: site})
                 inds = np.unravel_index(np.nanargmin(distances), distances.shape)
                 for xydim, ind in zip(dist.dims, inds, strict=False):
                     args[xydim].append(ind)
-            for xydim in dist.dims:
-                args[k] = xarray.DataArray(v, dims=ptdim)
+            for xydim in args.keys():
+                args[xydim] = xarray.DataArray(args[xydim], dims=ptdim)
             da = da.isel(**args)
             if add_distance or tolerance is not None:
                 dists = dist.isel(**args)

--- a/clisops/core/subset.py
+++ b/clisops/core/subset.py
@@ -1605,7 +1605,7 @@ def subset_gridpoint(
         lat_name = lat.name or "lat"
         # if 'lon' and 'lat' are present as data dimensions use the .sel method.
         dims_flag = lat_name in dims and lon_name in dims
-        if mask is None and method == "geographic" and dims_flag:
+        if method == "geographic" and mask is None and dims_flag:
             da = da.sel(lat=lat, lon=lon, method="nearest")
             if add_distance or tolerance is not None:
                 dists = distance(da, lon=lon, lat=lat)

--- a/tests/test_core_subset.py
+++ b/tests/test_core_subset.py
@@ -926,7 +926,7 @@ class TestDistance:
         da = xr.DataArray(0, coords={"lon": [0], "lat": [0]}, dims=["lon", "lat"])
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            d = subset.distance(da, lon=1, lat=1)
+            subset.distance(da, lon=1, lat=1)
             # Check no DeprecationWarning about array to scalar conversion
             deprecation_warnings = [
                 warning

--- a/tests/test_core_subset.py
+++ b/tests/test_core_subset.py
@@ -157,8 +157,7 @@ class TestSubsetGridPoint:
     nc_tasmax_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
     nc_tasmin_file = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
     nc_2dlonlat = "CRCM5/tasmax_bby_198406_se.nc"
-    
-    
+
     @pytest.mark.parametrize("method", ["distance", "geographic"])
     def test_time_simple(self, method, nimbus):
         da = xr.open_dataset(nimbus.fetch(self.nc_poslons)).tas
@@ -174,11 +173,13 @@ class TestSubsetGridPoint:
         np.testing.assert_array_equal(len(np.unique(out.time.dt.year)), 10)
         np.testing.assert_array_equal(out.time.dt.year.max(), int(yr_ed))
         np.testing.assert_array_equal(out.time.dt.year.min(), int(yr_st))
+
     @pytest.mark.parametrize("method", ["distance", "geographic"])
     def test_dataset(self, method, nimbus):
         da = xr.open_mfdataset(
             [nimbus.fetch(self.nc_tasmax_file), nimbus.fetch(self.nc_tasmin_file)],
-            combine="by_coords", compat="no_conflicts"
+            combine="by_coords",
+            compat="no_conflicts",
         )
         lon = -72.4
         lat = 46.1
@@ -198,6 +199,7 @@ class TestSubsetGridPoint:
 
         assert ("site" in out.dims) ^ (len(lat) == 1)
         assert ("distance" in out.coords) ^ (not add_distance)
+
     @pytest.mark.parametrize("method", ["distance", "geographic"])
     def test_irregular(self, method, nimbus):
         da = xr.open_dataset(nimbus.fetch(self.nc_2dlonlat)).tasmax
@@ -283,14 +285,14 @@ class TestSubsetGridPoint:
         np.testing.assert_array_equal(gp.da.isel(_site=0), gp.da.isel(_site=1))
         assert len(gp._site) == 2 and len(gp.lon) == 2 and len(gp.lat) == 2
         assert len(np.unique(gp._site)) == 2 and len(np.unique(gp.lon)) == 1 and len(np.unique(gp.lat)) == 1
-    
+
     @pytest.mark.parametrize("method", ["distance", "geographic"])
     def test_masked(self, method, nimbus):
         da = xr.open_dataset(nimbus.fetch(self.nc_tasmax_file)).tasmax
         # mask where there is valid data
         mask = ~np.isnan(da.isel(time=0))
         # lat lon close to coastline where there are masked gridcells in the dataset
-        # Halifax harbor 
+        # Halifax harbor
         lon = -63.48131910815178
         lat = 44.56206467361616
         out = subset.subset_gridpoint(da, lon=lon, lat=lat, method=method)
@@ -304,12 +306,12 @@ class TestSubsetGridPoint:
         da = xr.open_dataset(nimbus.fetch(self.nc_2dlonlat)).tasmax
         regions = gpd.read_file(clisops_test_data["multi_regions_geojson"])
         reg_mask = subset.create_mask(x_dim=da.lon, y_dim=da.lat, poly=regions)
-        da = da.where(reg_mask==0) #Quebec only 
-        
+        da = da.where(reg_mask == 0)  # Quebec only
+
         # mask where there is valid data
         mask = ~np.isnan(da.isel(time=0))
         # lat lon close to coastline where there are masked gridcells in the dataset
-        # Halifax harbor 
+        # Halifax harbor
         lon = -63.009725545080705
         lat = 48.25160814508184
         out = subset.subset_gridpoint(da, lon=lon, lat=lat, method=method)
@@ -926,7 +928,12 @@ class TestDistance:
             warnings.simplefilter("always")
             d = subset.distance(da, lon=1, lat=1)
             # Check no DeprecationWarning about array to scalar conversion
-            deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning) and "array with ndim > 0 to a scalar" in str(warning.message)]
+            deprecation_warnings = [
+                warning
+                for warning in w
+                if issubclass(warning.category, DeprecationWarning)
+                and "array with ndim > 0 to a scalar" in str(warning.message)
+            ]
             assert len(deprecation_warnings) == 0
 
 

--- a/tests/test_core_subset.py
+++ b/tests/test_core_subset.py
@@ -157,8 +157,10 @@ class TestSubsetGridPoint:
     nc_tasmax_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
     nc_tasmin_file = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
     nc_2dlonlat = "CRCM5/tasmax_bby_198406_se.nc"
-
-    def test_time_simple(self, nimbus):
+    
+    
+    @pytest.mark.parametrize("method", ["distance", "geographic"])
+    def test_time_simple(self, method, nimbus):
         da = xr.open_dataset(nimbus.fetch(self.nc_poslons)).tas
         da = da.assign_coords(lon=(da.lon - 360))
         lon = -72.4
@@ -166,42 +168,42 @@ class TestSubsetGridPoint:
         yr_st = "2050"
         yr_ed = "2059"
 
-        out = subset.subset_gridpoint(da, lon=lon, lat=lat, start_date=yr_st, end_date=yr_ed)
+        out = subset.subset_gridpoint(da, lon=lon, lat=lat, method=method, start_date=yr_st, end_date=yr_ed)
         np.testing.assert_almost_equal(out.lon, lon, 1)
         np.testing.assert_almost_equal(out.lat, lat, 1)
         np.testing.assert_array_equal(len(np.unique(out.time.dt.year)), 10)
         np.testing.assert_array_equal(out.time.dt.year.max(), int(yr_ed))
         np.testing.assert_array_equal(out.time.dt.year.min(), int(yr_st))
-
-    def test_dataset(self, nimbus):
+    @pytest.mark.parametrize("method", ["distance", "geographic"])
+    def test_dataset(self, method, nimbus):
         da = xr.open_mfdataset(
             [nimbus.fetch(self.nc_tasmax_file), nimbus.fetch(self.nc_tasmin_file)],
-            combine="by_coords",
+            combine="by_coords", compat="no_conflicts"
         )
         lon = -72.4
         lat = 46.1
-        out = subset.subset_gridpoint(da, lon=lon, lat=lat)
+        out = subset.subset_gridpoint(da, lon=lon, lat=lat, method=method)
         np.testing.assert_almost_equal(out.lon, lon, 1)
         np.testing.assert_almost_equal(out.lat, lat, 1)
         np.testing.assert_array_equal(out.tasmin.shape, out.tasmax.shape)
 
     @pytest.mark.parametrize("lon,lat", [([-72.4], [46.1]), ([-67.4, -67.3], [43.1, 46.1])])
     @pytest.mark.parametrize("add_distance", [True, False])
-    def test_simple(self, lat, lon, add_distance, nimbus):
+    @pytest.mark.parametrize("method", ["distance", "geographic"])
+    def test_simple(self, lat, lon, add_distance, method, nimbus):
         da = xr.open_dataset(nimbus.fetch(self.nc_tasmax_file)).tasmax
-
-        out = subset.subset_gridpoint(da, lon=lon, lat=lat, add_distance=add_distance)
+        out = subset.subset_gridpoint(da, lon=lon, lat=lat, add_distance=add_distance, method=method)
         np.testing.assert_almost_equal(out.lon, lon, 1)
         np.testing.assert_almost_equal(out.lat, lat, 1)
 
         assert ("site" in out.dims) ^ (len(lat) == 1)
         assert ("distance" in out.coords) ^ (not add_distance)
-
-    def test_irregular(self, nimbus):
+    @pytest.mark.parametrize("method", ["distance", "geographic"])
+    def test_irregular(self, method, nimbus):
         da = xr.open_dataset(nimbus.fetch(self.nc_2dlonlat)).tasmax
         lon = -72.4
         lat = 46.1
-        out = subset.subset_gridpoint(da, lon=lon, lat=lat)
+        out = subset.subset_gridpoint(da, lon=lon, lat=lat, method=method)
         np.testing.assert_almost_equal(out.lon, lon, 1)
         np.testing.assert_almost_equal(out.lat, lat, 1)
         assert "site" not in out.dims
@@ -235,7 +237,7 @@ class TestSubsetGridPoint:
         out1 = subset.subset_gridpoint(daT, lon=lon, lat=lat)
         np.testing.assert_almost_equal(out1.lon, lon, 1)
         np.testing.assert_almost_equal(out1.lat, lat, 1)
-        np.testing.assert_array_equal(out, out1)
+        np.testing.assert_array_equal(out, out1.transpose(*out.dims))
 
         # Dataset with tasmax, lon and lat as data variables (i.e. lon, lat not coords of tasmax)
         daT1 = xr.DataArray(np.transpose(da1.values), dims=dims)
@@ -250,11 +252,11 @@ class TestSubsetGridPoint:
         out2 = subset.subset_gridpoint(dsT, lon=lon, lat=lat)
         np.testing.assert_almost_equal(out2.lon, lon, 1)
         np.testing.assert_almost_equal(out2.lat, lat, 1)
-        np.testing.assert_array_equal(out, out2.tasmax)
+        np.testing.assert_array_equal(out, out2.tasmax.transpose(*out.dims))
 
         # Dataset with lon and lat as 1D arrays
         lon = -60
-        lat = -45
+        lat = 45
         da = xr.DataArray(
             np.random.rand(5, 4),
             dims=("time", "site"),
@@ -271,6 +273,50 @@ class TestSubsetGridPoint:
         np.testing.assert_almost_equal(gp.lon, lon)
         np.testing.assert_almost_equal(gp.lat, lat)
         assert gp.site == 0
+
+        # extracting two points close together should give a duplicate point in the output
+        # extract the same grid cell for two 'sites'
+        lon = [-60, -59]
+        lat = [-45, 45]
+        gp = subset.subset_gridpoint(ds, lon=lon, lat=lat)
+        # 'site' dim already in input da so output has '_site' dim
+        np.testing.assert_array_equal(gp.da.isel(_site=0), gp.da.isel(_site=1))
+        assert len(gp._site) == 2 and len(gp.lon) == 2 and len(gp.lat) == 2
+        assert len(np.unique(gp._site)) == 2 and len(np.unique(gp.lon)) == 1 and len(np.unique(gp.lat)) == 1
+    
+    @pytest.mark.parametrize("method", ["distance", "geographic"])
+    def test_masked(self, method, nimbus):
+        da = xr.open_dataset(nimbus.fetch(self.nc_tasmax_file)).tasmax
+        # mask where there is valid data
+        mask = ~np.isnan(da.isel(time=0))
+        # lat lon close to coastline where there are masked gridcells in the dataset
+        # Halifax harbor 
+        lon = -63.48131910815178
+        lat = 44.56206467361616
+        out = subset.subset_gridpoint(da, lon=lon, lat=lat, method=method)
+        out_mask = subset.subset_gridpoint(da, lon=lon, lat=lat, method=method, mask=mask)
+        assert out.isnull().all()
+        assert out_mask.notnull().all()
+        np.testing.assert_almost_equal(out_mask.mean(), 284.91546631)
+
+    @pytest.mark.parametrize("method", ["distance", "geographic"])
+    def test_masked_irregular(self, method, nimbus, clisops_test_data):
+        da = xr.open_dataset(nimbus.fetch(self.nc_2dlonlat)).tasmax
+        regions = gpd.read_file(clisops_test_data["multi_regions_geojson"])
+        reg_mask = subset.create_mask(x_dim=da.lon, y_dim=da.lat, poly=regions)
+        da = da.where(reg_mask==0) #Quebec only 
+        
+        # mask where there is valid data
+        mask = ~np.isnan(da.isel(time=0))
+        # lat lon close to coastline where there are masked gridcells in the dataset
+        # Halifax harbor 
+        lon = -63.009725545080705
+        lat = 48.25160814508184
+        out = subset.subset_gridpoint(da, lon=lon, lat=lat, method=method)
+        out_mask = subset.subset_gridpoint(da, lon=lon, lat=lat, method=method, mask=mask)
+        assert out.isnull().all()
+        assert out_mask.notnull().all()
+        np.testing.assert_almost_equal(out_mask.mean(), 285.34141642)
 
     def test_positive_lons(self, nimbus):
         da = xr.open_dataset(nimbus.fetch(self.nc_poslons)).tas
@@ -300,7 +346,8 @@ class TestSubsetGridPoint:
         out = subset.subset_gridpoint(da, lon=lon, lat=lat, tolerance=1)
         assert out.isnull().all()
 
-        subset.subset_gridpoint(da, lon=lon, lat=lat, tolerance=1e5)
+        out = subset.subset_gridpoint(da, lon=lon, lat=lat, tolerance=1e5)
+        assert out.notnull().all()
 
 
 class TestSubsetBbox:
@@ -871,6 +918,16 @@ class TestDistance:
         k = np.argmin(d.data)
         i, j = np.unravel_index(k, da.data.shape)
         assert d[i, j] == d.min()
+
+    def test_no_numpy_deprecation_warning(self):
+        # Test that distance function doesn't trigger NumPy deprecation warnings
+        da = xr.DataArray(0, coords={"lon": [0], "lat": [0]}, dims=["lon", "lat"])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            d = subset.distance(da, lon=1, lat=1)
+            # Check no DeprecationWarning about array to scalar conversion
+            deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning) and "array with ndim > 0 to a scalar" in str(warning.message)]
+            assert len(deprecation_warnings) == 0
 
 
 class TestSubsetLevel:

--- a/tests/test_core_subset.py
+++ b/tests/test_core_subset.py
@@ -921,21 +921,6 @@ class TestDistance:
         i, j = np.unravel_index(k, da.data.shape)
         assert d[i, j] == d.min()
 
-    def test_no_numpy_deprecation_warning(self):
-        # Test that distance function doesn't trigger NumPy deprecation warnings
-        da = xr.DataArray(0, coords={"lon": [0], "lat": [0]}, dims=["lon", "lat"])
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            subset.distance(da, lon=1, lat=1)
-            # Check no DeprecationWarning about array to scalar conversion
-            deprecation_warnings = [
-                warning
-                for warning in w
-                if issubclass(warning.category, DeprecationWarning)
-                and "array with ndim > 0 to a scalar" in str(warning.message)
-            ]
-            assert len(deprecation_warnings) == 0
-
 
 class TestSubsetLevel:
     nc_plev = "cmip6/o3_Amon_GFDL-ESM4_historical_r1i1p1f1_gr1_185001-194912.nc"


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)

### What kind of change does this PR introduce?: <!--(Bug fix, feature, docs update, etc.)-->

- Adds ability to use a boolean data mask with `subset_gridpoint` where selected points must be within the mask (`True`)
- Allows choice between using true world distance or nearest neighbour based on geographic (lat, lon) coords for selection of points for both regular and irregular grids. Current implementation is inconsistent and uses lat,lon nearest for regular grids and true distance on irregular 

### Does this PR introduce a breaking change?: <!--(Has there been an API change? New dependencies?)-->
The default method is set for `distance` (more accurate but could potentially be slower for large grids). As such the default behaviour is different for regular lat, lon grids potentially causing small differences in selected locations (most likely close to poles if at all present)

### Other information: <!--(Relevant discussion threads? Outside documentation pages?)-->
